### PR TITLE
ホーム画面作成

### DIFF
--- a/Qiita_SwiftUI.xcodeproj/project.pbxproj
+++ b/Qiita_SwiftUI.xcodeproj/project.pbxproj
@@ -63,6 +63,8 @@
 		E2729DE1264EC601009473D0 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DE0264EC601009473D0 /* HomeView.swift */; };
 		E2729DE3264ECA96009473D0 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DE2264ECA96009473D0 /* HomeViewModel.swift */; };
 		E2729DE6264ECDA7009473D0 /* ItemListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DE5264ECDA7009473D0 /* ItemListView.swift */; };
+		E2729DE9264F0C82009473D0 /* FetchImage in Frameworks */ = {isa = PBXBuildFile; productRef = E2729DE8264F0C82009473D0 /* FetchImage */; };
+		E2729DEB264F0D43009473D0 /* ImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DEA264F0D43009473D0 /* ImageView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -142,6 +144,7 @@
 		E2729DE0264EC601009473D0 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		E2729DE2264ECA96009473D0 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		E2729DE5264ECDA7009473D0 /* ItemListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemListView.swift; sourceTree = "<group>"; };
+		E2729DEA264F0D43009473D0 /* ImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -152,6 +155,7 @@
 				E20DD37D25FF47E600735B0A /* KeychainAccess in Frameworks */,
 				E20DD36425FF460500735B0A /* Moya in Frameworks */,
 				E20DD38325FF483200735B0A /* SwiftyBeaver in Frameworks */,
+				E2729DE9264F0C82009473D0 /* FetchImage in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -424,6 +428,7 @@
 			isa = PBXGroup;
 			children = (
 				E20DD3C525FF9E3A00735B0A /* SafariView.swift */,
+				E2729DEA264F0D43009473D0 /* ImageView.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -465,6 +470,7 @@
 				E20DD36325FF460500735B0A /* Moya */,
 				E20DD37C25FF47E600735B0A /* KeychainAccess */,
 				E20DD38225FF483200735B0A /* SwiftyBeaver */,
+				E2729DE8264F0C82009473D0 /* FetchImage */,
 			);
 			productName = Qiita_SwiftUI;
 			productReference = E20DD2BF25FF325600735B0A /* Qiita_SwiftUI.app */;
@@ -541,6 +547,7 @@
 				E20DD36225FF460500735B0A /* XCRemoteSwiftPackageReference "Moya" */,
 				E20DD37B25FF47E600735B0A /* XCRemoteSwiftPackageReference "KeychainAccess" */,
 				E20DD38125FF483200735B0A /* XCRemoteSwiftPackageReference "SwiftyBeaver" */,
+				E2729DE7264F0C82009473D0 /* XCRemoteSwiftPackageReference "FetchImage" */,
 			);
 			productRefGroup = E20DD2C025FF325600735B0A /* Products */;
 			projectDirPath = "";
@@ -597,6 +604,7 @@
 				E20DD35225FF44C600735B0A /* ItemTarget.swift in Sources */,
 				E20DD32325FF40EE00735B0A /* ItemRepository.swift in Sources */,
 				E20DD34625FF44BA00735B0A /* API.swift in Sources */,
+				E2729DEB264F0D43009473D0 /* ImageView.swift in Sources */,
 				E20DD31725FF403D00735B0A /* ItemTag.swift in Sources */,
 				E20DD3A825FF8FE400735B0A /* LaunchView.swift in Sources */,
 				E20DD33725FF40FC00735B0A /* TagService.swift in Sources */,
@@ -976,6 +984,14 @@
 				minimumVersion = 1.9.3;
 			};
 		};
+		E2729DE7264F0C82009473D0 /* XCRemoteSwiftPackageReference "FetchImage" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kean/FetchImage.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.4.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -993,6 +1009,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = E20DD38125FF483200735B0A /* XCRemoteSwiftPackageReference "SwiftyBeaver" */;
 			productName = SwiftyBeaver;
+		};
+		E2729DE8264F0C82009473D0 /* FetchImage */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E2729DE7264F0C82009473D0 /* XCRemoteSwiftPackageReference "FetchImage" */;
+			productName = FetchImage;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Qiita_SwiftUI.xcodeproj/project.pbxproj
+++ b/Qiita_SwiftUI.xcodeproj/project.pbxproj
@@ -60,6 +60,9 @@
 		E20DD3C625FF9E3A00735B0A /* SafariView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20DD3C525FF9E3A00735B0A /* SafariView.swift */; };
 		E20DD3CF25FFA99100735B0A /* .env in Resources */ = {isa = PBXBuildFile; fileRef = E20DD3CD25FFA99100735B0A /* .env */; };
 		E20DD3D025FFA99100735B0A /* .env.sample in Resources */ = {isa = PBXBuildFile; fileRef = E20DD3CE25FFA99100735B0A /* .env.sample */; };
+		E2729DE1264EC601009473D0 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DE0264EC601009473D0 /* HomeView.swift */; };
+		E2729DE3264ECA96009473D0 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DE2264ECA96009473D0 /* HomeViewModel.swift */; };
+		E2729DE6264ECDA7009473D0 /* ItemListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DE5264ECDA7009473D0 /* ItemListView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -136,6 +139,9 @@
 		E20DD3C525FF9E3A00735B0A /* SafariView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariView.swift; sourceTree = "<group>"; };
 		E20DD3CD25FFA99100735B0A /* .env */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = .env; sourceTree = "<group>"; };
 		E20DD3CE25FFA99100735B0A /* .env.sample */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = .env.sample; sourceTree = "<group>"; };
+		E2729DE0264EC601009473D0 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
+		E2729DE2264ECA96009473D0 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
+		E2729DE5264ECDA7009473D0 /* ItemListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemListView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -367,6 +373,8 @@
 				E20DD39E25FF8D7A00735B0A /* Launch */,
 				E20DD39F25FF8D8000735B0A /* Login */,
 				E20DD3A025FF8D8D00735B0A /* Main */,
+				E2729DE4264ECD8C009473D0 /* ItemList */,
+				E2729DDF264EC5EC009473D0 /* Home */,
 			);
 			path = Screen;
 			sourceTree = "<group>";
@@ -418,6 +426,23 @@
 				E20DD3C525FF9E3A00735B0A /* SafariView.swift */,
 			);
 			path = Common;
+			sourceTree = "<group>";
+		};
+		E2729DDF264EC5EC009473D0 /* Home */ = {
+			isa = PBXGroup;
+			children = (
+				E2729DE0264EC601009473D0 /* HomeView.swift */,
+				E2729DE2264ECA96009473D0 /* HomeViewModel.swift */,
+			);
+			path = Home;
+			sourceTree = "<group>";
+		};
+		E2729DE4264ECD8C009473D0 /* ItemList */ = {
+			isa = PBXGroup;
+			children = (
+				E2729DE5264ECDA7009473D0 /* ItemListView.swift */,
+			);
+			path = ItemList;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -579,8 +604,10 @@
 				E20DD33325FF40FC00735B0A /* LikeService.swift in Sources */,
 				E20DD30725FF3EAA00735B0A /* AppContext.swift in Sources */,
 				E20DD32425FF40EE00735B0A /* LikeRepository.swift in Sources */,
+				E2729DE6264ECDA7009473D0 /* ItemListView.swift in Sources */,
 				E20DD3C625FF9E3A00735B0A /* SafariView.swift in Sources */,
 				E20DD30825FF3EAA00735B0A /* AppError.swift in Sources */,
+				E2729DE1264EC601009473D0 /* HomeView.swift in Sources */,
 				E20DD30625FF3EAA00735B0A /* AppContainer.swift in Sources */,
 				E20DD32525FF40EE00735B0A /* StockRepository.swift in Sources */,
 				E20DD32625FF40EE00735B0A /* TagRepository.swift in Sources */,
@@ -601,6 +628,7 @@
 				E20DD3AD25FF902300735B0A /* LoginView.swift in Sources */,
 				E20DD31525FF403D00735B0A /* User.swift in Sources */,
 				E20DD3B225FF903B00735B0A /* MainView.swift in Sources */,
+				E2729DE3264ECA96009473D0 /* HomeViewModel.swift in Sources */,
 				E20DD37425FF479E00735B0A /* Keychains.swift in Sources */,
 				E20DD3A325FF8F5700735B0A /* AuthState.swift in Sources */,
 				E20DD2C325FF325600735B0A /* Qiita_SwiftUIApp.swift in Sources */,

--- a/Qiita_SwiftUI.xcodeproj/project.pbxproj
+++ b/Qiita_SwiftUI.xcodeproj/project.pbxproj
@@ -65,6 +65,8 @@
 		E2729DE6264ECDA7009473D0 /* ItemListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DE5264ECDA7009473D0 /* ItemListView.swift */; };
 		E2729DE9264F0C82009473D0 /* FetchImage in Frameworks */ = {isa = PBXBuildFile; productRef = E2729DE8264F0C82009473D0 /* FetchImage */; };
 		E2729DEB264F0D43009473D0 /* ImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DEA264F0D43009473D0 /* ImageView.swift */; };
+		E2729DEE264F15C4009473D0 /* ItemDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DED264F15C4009473D0 /* ItemDetailView.swift */; };
+		E2729DF0264F18F0009473D0 /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DEF264F18F0009473D0 /* WebView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -145,6 +147,8 @@
 		E2729DE2264ECA96009473D0 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		E2729DE5264ECDA7009473D0 /* ItemListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemListView.swift; sourceTree = "<group>"; };
 		E2729DEA264F0D43009473D0 /* ImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageView.swift; sourceTree = "<group>"; };
+		E2729DED264F15C4009473D0 /* ItemDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemDetailView.swift; sourceTree = "<group>"; };
+		E2729DEF264F18F0009473D0 /* WebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -378,6 +382,7 @@
 				E20DD39F25FF8D8000735B0A /* Login */,
 				E20DD3A025FF8D8D00735B0A /* Main */,
 				E2729DE4264ECD8C009473D0 /* ItemList */,
+				E2729DEC264F1582009473D0 /* ItemDetail */,
 				E2729DDF264EC5EC009473D0 /* Home */,
 			);
 			path = Screen;
@@ -429,6 +434,7 @@
 			children = (
 				E20DD3C525FF9E3A00735B0A /* SafariView.swift */,
 				E2729DEA264F0D43009473D0 /* ImageView.swift */,
+				E2729DEF264F18F0009473D0 /* WebView.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -448,6 +454,14 @@
 				E2729DE5264ECDA7009473D0 /* ItemListView.swift */,
 			);
 			path = ItemList;
+			sourceTree = "<group>";
+		};
+		E2729DEC264F1582009473D0 /* ItemDetail */ = {
+			isa = PBXGroup;
+			children = (
+				E2729DED264F15C4009473D0 /* ItemDetailView.swift */,
+			);
+			path = ItemDetail;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -612,6 +626,7 @@
 				E20DD33325FF40FC00735B0A /* LikeService.swift in Sources */,
 				E20DD30725FF3EAA00735B0A /* AppContext.swift in Sources */,
 				E20DD32425FF40EE00735B0A /* LikeRepository.swift in Sources */,
+				E2729DEE264F15C4009473D0 /* ItemDetailView.swift in Sources */,
 				E2729DE6264ECDA7009473D0 /* ItemListView.swift in Sources */,
 				E20DD3C625FF9E3A00735B0A /* SafariView.swift in Sources */,
 				E20DD30825FF3EAA00735B0A /* AppError.swift in Sources */,
@@ -636,6 +651,7 @@
 				E20DD3AD25FF902300735B0A /* LoginView.swift in Sources */,
 				E20DD31525FF403D00735B0A /* User.swift in Sources */,
 				E20DD3B225FF903B00735B0A /* MainView.swift in Sources */,
+				E2729DF0264F18F0009473D0 /* WebView.swift in Sources */,
 				E2729DE3264ECA96009473D0 /* HomeViewModel.swift in Sources */,
 				E20DD37425FF479E00735B0A /* Keychains.swift in Sources */,
 				E20DD3A325FF8F5700735B0A /* AuthState.swift in Sources */,

--- a/Qiita_SwiftUI.xcodeproj/project.pbxproj
+++ b/Qiita_SwiftUI.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		E2729DEB264F0D43009473D0 /* ImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DEA264F0D43009473D0 /* ImageView.swift */; };
 		E2729DEE264F15C4009473D0 /* ItemDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DED264F15C4009473D0 /* ItemDetailView.swift */; };
 		E2729DF0264F18F0009473D0 /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DEF264F18F0009473D0 /* WebView.swift */; };
+		E2729DF2264F24F8009473D0 /* ItemStubService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DF1264F24F8009473D0 /* ItemStubService.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -149,6 +150,7 @@
 		E2729DEA264F0D43009473D0 /* ImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageView.swift; sourceTree = "<group>"; };
 		E2729DED264F15C4009473D0 /* ItemDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemDetailView.swift; sourceTree = "<group>"; };
 		E2729DEF264F18F0009473D0 /* WebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebView.swift; sourceTree = "<group>"; };
+		E2729DF1264F24F8009473D0 /* ItemStubService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemStubService.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -425,6 +427,7 @@
 			isa = PBXGroup;
 			children = (
 				E20DD3BA25FF910E00735B0A /* AuthStubService.swift */,
+				E2729DF1264F24F8009473D0 /* ItemStubService.swift */,
 			);
 			path = Stub;
 			sourceTree = "<group>";
@@ -616,6 +619,7 @@
 				E20DD2FB25FF3DE000735B0A /* AppConstant.swift in Sources */,
 				E20DD33525FF40FC00735B0A /* AuthService.swift in Sources */,
 				E20DD35225FF44C600735B0A /* ItemTarget.swift in Sources */,
+				E2729DF2264F24F8009473D0 /* ItemStubService.swift in Sources */,
 				E20DD32325FF40EE00735B0A /* ItemRepository.swift in Sources */,
 				E20DD34625FF44BA00735B0A /* API.swift in Sources */,
 				E2729DEB264F0D43009473D0 /* ImageView.swift in Sources */,

--- a/Qiita_SwiftUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Qiita_SwiftUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "FetchImage",
+        "repositoryURL": "https://github.com/kean/FetchImage.git",
+        "state": {
+          "branch": null,
+          "revision": "cac844a0dea908c6e068fc8c6a0f949179c7f876",
+          "version": "0.4.0"
+        }
+      },
+      {
         "package": "KeychainAccess",
         "repositoryURL": "https://github.com/kishikawakatsumi/KeychainAccess.git",
         "state": {
@@ -44,6 +53,15 @@
           "branch": null,
           "revision": "7a46a5fc86cb917f69e3daf79fcb045283d8f008",
           "version": "8.1.2"
+        }
+      },
+      {
+        "package": "Nuke",
+        "repositoryURL": "https://github.com/kean/Nuke.git",
+        "state": {
+          "branch": null,
+          "revision": "8e0f42d1d9f30d816f3c565aa6193d9363325157",
+          "version": "9.6.0"
         }
       },
       {

--- a/Qiita_SwiftUI/Presentation/Common/ImageView.swift
+++ b/Qiita_SwiftUI/Presentation/Common/ImageView.swift
@@ -1,0 +1,28 @@
+//
+//  ImageView.swift
+//  Qiita_SwiftUI
+//
+//  Created by kntk on 2021/05/15.
+//
+
+import SwiftUI
+import FetchImage
+
+struct ImageView: View {
+    let url: URL
+
+    @StateObject private var image = FetchImage()
+
+    var body: some View {
+        ZStack {
+            Rectangle().fill(Color.gray)
+            image.view?
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .clipped()
+        }
+        .onAppear { image.load(url) }
+        .onChange(of: url) { image.load($0) }
+        .onDisappear(perform: image.reset)
+    }
+}

--- a/Qiita_SwiftUI/Presentation/Common/WebView.swift
+++ b/Qiita_SwiftUI/Presentation/Common/WebView.swift
@@ -1,0 +1,22 @@
+//
+//  WebView.swift
+//  Qiita_SwiftUI
+//
+//  Created by kntk on 2021/05/15.
+//
+
+import SwiftUI
+import WebKit
+
+struct WebView: UIViewRepresentable {
+
+    var url: URL
+
+    func makeUIView(context: Context) -> WKWebView {
+        return WKWebView()
+    }
+
+    func updateUIView(_ uiView: WKWebView, context: Context) {
+        uiView.load(URLRequest(url: url))
+    }
+}

--- a/Qiita_SwiftUI/Presentation/Screen/Home/HomeView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Home/HomeView.swift
@@ -31,6 +31,6 @@ struct HomeView: View {
 
 struct HomeView_Previews: PreviewProvider {
     static var previews: some View {
-        HomeView(itemRepository: AppContainer.shared.itemRepository)
+        HomeView(itemRepository: ItemStubService())
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/Home/HomeView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Home/HomeView.swift
@@ -1,0 +1,36 @@
+//
+//  HomeView.swift
+//  Qiita_SwiftUI
+//
+//  Created by kntk on 2021/05/14.
+//
+
+import SwiftUI
+
+struct HomeView: View {
+
+    // MARK: - Property
+
+    @ObservedObject private var viewModel: HomeViewModel
+
+    // MARK: - Initializer
+
+    init(itemRepository: ItemRepository) {
+        self.viewModel = HomeViewModel(itemRepository: itemRepository)
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        NavigationView {
+            ItemListView(items: $viewModel.items)
+                .navigationBarTitle("Home", displayMode: .inline)
+        }
+    }
+}
+
+struct HomeView_Previews: PreviewProvider {
+    static var previews: some View {
+        HomeView(itemRepository: AppContainer.shared.itemRepository)
+    }
+}

--- a/Qiita_SwiftUI/Presentation/Screen/Home/HomeViewModel.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Home/HomeViewModel.swift
@@ -1,0 +1,44 @@
+//
+//  HomeViewModel.swift
+//  Qiita_SwiftUI
+//
+//  Created by kntk on 2021/05/15.
+//
+
+import Foundation
+import Combine
+
+final class HomeViewModel: ObservableObject {
+
+    // MARK: - Property
+
+    @Published var items: [Item] = []
+
+    private let itemRepository: ItemRepository
+    private var cancellables = [AnyCancellable]()
+
+    // MARK: - Initializer
+
+    init(itemRepository: ItemRepository) {
+        self.itemRepository = itemRepository
+
+        fetchItems()
+    }
+
+    // MARK: - Public
+
+    func fetchItems() {
+        itemRepository.getItems(page: 1)
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { completion in
+                switch completion {
+                case .finished:
+                    break
+                case .failure(let error):
+                    Logger.error(error)
+                }
+            }, receiveValue: { items in
+                self.items = items
+            }).store(in: &cancellables)
+    }
+}

--- a/Qiita_SwiftUI/Presentation/Screen/ItemDetail/ItemDetailView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/ItemDetail/ItemDetailView.swift
@@ -1,0 +1,28 @@
+//
+//  ItemDetailView.swift
+//  Qiita_SwiftUI
+//
+//  Created by kntk on 2021/05/15.
+//
+
+import SwiftUI
+
+struct ItemDetailView: View {
+
+    // MARK: - Property
+
+    var item: Item
+
+    // MARK: - Body
+
+    var body: some View {
+        WebView(url: item.url)
+            .navigationTitle(item.title)
+    }
+}
+
+struct ItemDetailView_Previews: PreviewProvider {
+    static var previews: some View {
+        ItemDetailView(item: Item(title: "Hello Wordl", id: "1", url: URL(string: "https://qiita.com/api/v2/docs")!, likesCount: 0, createdAt: Date(), user: User(id: "1", name: "hoge", description: "", profileImageUrl: URL(string: "https://qiita.com/api/v2/docs")!, itemsCount: 0, followeesCount: 0, followersCount: 0)))
+    }
+}

--- a/Qiita_SwiftUI/Presentation/Screen/ItemDetail/ItemDetailView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/ItemDetail/ItemDetailView.swift
@@ -23,6 +23,6 @@ struct ItemDetailView: View {
 
 struct ItemDetailView_Previews: PreviewProvider {
     static var previews: some View {
-        ItemDetailView(item: Item(title: "Hello Wordl", id: "1", url: URL(string: "https://qiita.com/api/v2/docs")!, likesCount: 0, createdAt: Date(), user: User(id: "1", name: "hoge", description: "", profileImageUrl: URL(string: "https://qiita.com/api/v2/docs")!, itemsCount: 0, followeesCount: 0, followersCount: 0)))
+        ItemDetailView(item: ItemStubService.items[0])
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/ItemList/ItemListView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/ItemList/ItemListView.swift
@@ -29,9 +29,20 @@ struct ItemListItem: View {
     var item: Item
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(item.title)
-        }
+        HStack {
+            ImageView(url: item.user.profileImageUrl)
+                .frame(width: 40, height: 40)
+                .cornerRadius(4.0)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(item.title)
+                    .font(.system(size: 14, weight: .medium))
+
+                Text("by \(item.user.name)")
+                    .foregroundColor(.secondary)
+                    .font(.system(size: 12))
+            }
+        }.padding(.vertical, 8)
     }
 }
 

--- a/Qiita_SwiftUI/Presentation/Screen/ItemList/ItemListView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/ItemList/ItemListView.swift
@@ -1,0 +1,45 @@
+//
+//  ItemListView.swift
+//  Qiita_SwiftUI
+//
+//  Created by kntk on 2021/05/15.
+//
+
+import SwiftUI
+
+struct ItemListView: View {
+
+    // MARK: - Property
+
+    @Binding var items: [Item]
+
+    // MARK: - Body
+
+    var body: some View {
+        List {
+            ForEach(items) { item in
+                ItemListItem(item: item)
+            }
+        }.listStyle(PlainListStyle())
+    }
+}
+
+struct ItemListItem: View {
+
+    var item: Item
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(item.title)
+        }
+    }
+}
+
+struct ItemListView_Previews: PreviewProvider {
+
+    @State static var items: [Item] = .init(repeating: Item(title: "Hello Wordl", id: "1", url: URL(string: "https://qiita.com/api/v2/docs")!, likesCount: 0, createdAt: Date(), user: User(id: "1", name: "hoge", description: "", profileImageUrl: URL(string: "https://qiita.com/api/v2/docs")!, itemsCount: 0, followeesCount: 0, followersCount: 0)), count: 10)
+
+    static var previews: some View {
+        ItemListView(items: $items)
+    }
+}

--- a/Qiita_SwiftUI/Presentation/Screen/ItemList/ItemListView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/ItemList/ItemListView.swift
@@ -35,13 +35,23 @@ struct ItemListItem: View {
                     .frame(width: 40, height: 40)
                     .cornerRadius(4.0)
 
-                VStack(alignment: .leading, spacing: 4) {
+                VStack(alignment: .leading, spacing: 6) {
                     Text(item.title)
                         .font(.system(size: 14, weight: .medium))
 
-                    Text("by \(item.user.name)")
-                        .foregroundColor(.secondary)
-                        .font(.system(size: 12))
+                    HStack {
+                        Text("@\(item.user.id)")
+                            .foregroundColor(.secondary)
+                            .font(.system(size: 12))
+
+                        Image(systemName: "hand.thumbsup")
+                            .frame(width: 4, height: 12)
+                            .font(.system(size: 12))
+
+                        Text(item.likesCount.description)
+                            .foregroundColor(.secondary)
+                            .font(.system(size: 12))
+                    }
                 }
             }.padding(.vertical, 8)
         }

--- a/Qiita_SwiftUI/Presentation/Screen/ItemList/ItemListView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/ItemList/ItemListView.swift
@@ -60,7 +60,7 @@ struct ItemListItem: View {
 
 struct ItemListView_Previews: PreviewProvider {
 
-    @State static var items: [Item] = .init(repeating: Item(title: "Hello Wordl", id: "1", url: URL(string: "https://qiita.com/api/v2/docs")!, likesCount: 0, createdAt: Date(), user: User(id: "1", name: "hoge", description: "", profileImageUrl: URL(string: "https://qiita.com/api/v2/docs")!, itemsCount: 0, followeesCount: 0, followersCount: 0)), count: 10)
+    @State static var items: [Item] = ItemStubService.items
 
     static var previews: some View {
         ItemListView(items: $items)

--- a/Qiita_SwiftUI/Presentation/Screen/ItemList/ItemListView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/ItemList/ItemListView.swift
@@ -29,20 +29,22 @@ struct ItemListItem: View {
     var item: Item
 
     var body: some View {
-        HStack {
-            ImageView(url: item.user.profileImageUrl)
-                .frame(width: 40, height: 40)
-                .cornerRadius(4.0)
+        NavigationLink(destination: ItemDetailView(item: item)) {
+            HStack {
+                ImageView(url: item.user.profileImageUrl)
+                    .frame(width: 40, height: 40)
+                    .cornerRadius(4.0)
 
-            VStack(alignment: .leading, spacing: 4) {
-                Text(item.title)
-                    .font(.system(size: 14, weight: .medium))
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(item.title)
+                        .font(.system(size: 14, weight: .medium))
 
-                Text("by \(item.user.name)")
-                    .foregroundColor(.secondary)
-                    .font(.system(size: 12))
-            }
-        }.padding(.vertical, 8)
+                    Text("by \(item.user.name)")
+                        .foregroundColor(.secondary)
+                        .font(.system(size: 12))
+                }
+            }.padding(.vertical, 8)
+        }
     }
 }
 

--- a/Qiita_SwiftUI/Presentation/Screen/Launch/LaunchView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Launch/LaunchView.swift
@@ -14,12 +14,13 @@ struct LaunchView: View {
     @EnvironmentObject var authState: AuthState
 
     let authRepository: AuthRepository
+    let itemRepository: ItemRepository
 
     // MARK: - Body
 
     var body: some View {
         if authState.isSignedin {
-            MainView()
+            MainView(itemRepository: itemRepository)
         } else {
             LoginView(authRepository: authRepository)
         }
@@ -28,7 +29,7 @@ struct LaunchView: View {
 
 struct LaunchView_Previews: PreviewProvider {
     static var previews: some View {
-        LaunchView(authRepository: AuthStubService())
+        LaunchView(authRepository: AuthStubService(), itemRepository: ItemStubService())
             .environmentObject(AuthState(authRepository: AuthStubService()))
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/Main/MainView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Main/MainView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct MainView: View {
     var body: some View {
         TabView {
-            Text("Home")
+            HomeView(itemRepository: AppContainer.shared.itemRepository)
                 .tabItem {
                     Image(systemName: "house")
                     Text("Home")

--- a/Qiita_SwiftUI/Presentation/Screen/Main/MainView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Main/MainView.swift
@@ -8,9 +8,16 @@
 import SwiftUI
 
 struct MainView: View {
+
+    // MARK: - Property
+
+    var itemRepository: ItemRepository
+
+    // MARK: - Body
+
     var body: some View {
         TabView {
-            HomeView(itemRepository: AppContainer.shared.itemRepository)
+            HomeView(itemRepository: itemRepository)
                 .tabItem {
                     Image(systemName: "house")
                     Text("Home")
@@ -36,6 +43,6 @@ struct MainView: View {
 
 struct MainView_Previews: PreviewProvider {
     static var previews: some View {
-        MainView()
+        MainView(itemRepository: ItemStubService())
     }
 }

--- a/Qiita_SwiftUI/Qiita_SwiftUIApp.swift
+++ b/Qiita_SwiftUI/Qiita_SwiftUIApp.swift
@@ -12,7 +12,7 @@ struct Qiita_SwiftUIApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     var body: some Scene {
         WindowGroup {
-            LaunchView(authRepository: AppContainer.shared.authRepository)
+            LaunchView(authRepository: AppContainer.shared.authRepository, itemRepository: AppContainer.shared.itemRepository)
                 .environmentObject(AuthState(authRepository: AppContainer.shared.authRepository))
         }
     }

--- a/Qiita_SwiftUI/Service/Stub/AuthStubService.swift
+++ b/Qiita_SwiftUI/Service/Stub/AuthStubService.swift
@@ -10,13 +10,7 @@ import Foundation
 
 final class AuthStubService: AuthRepository {
 
-    private let user = User(id: "1111",
-                            name: "hoge",
-                            description: "hogeです。\nよろしくお願いします。",
-                            profileImageUrl: URL(string: "https://avatars.githubusercontent.com/u/44288050?s=400&u=57fbf71e9e2e411af3da17f82051cf83cdb0df56&v=4")!,
-                            itemsCount: 2,
-                            followeesCount: 3,
-                            followersCount: 4)
+    private let user = User(id: "kntkymt", name: "kntkymt", description: "iOSエンジニアです", profileImageUrl: URL(string: "https://avatars2.githubusercontent.com/u/44288050?v=4")!, itemsCount: 4, followeesCount: 3, followersCount: 3)
 
     private let authModel = AuthModel(clientId: "stub id", scopes: [], token: "stub token")
 

--- a/Qiita_SwiftUI/Service/Stub/ItemStubService.swift
+++ b/Qiita_SwiftUI/Service/Stub/ItemStubService.swift
@@ -1,0 +1,45 @@
+//
+//  ItemStubService.swift
+//  Qiita_SwiftUI
+//
+//  Created by kntk on 2021/05/15.
+//
+
+import Foundation
+import Combine
+
+final class ItemStubService: ItemRepository {
+
+    // MARK: - Property
+
+    static let items: [Item] = (0..<10).map { Item(title: "Hello Word!", id: $0.description, url: URL(string: "https://qiita.com")!, likesCount: $0.isMultiple(of: 2) ? 3 * $0 : $0, createdAt: Date(), user: User(id: "kntkymt", name: "kntkymt", description: "iOSエンジニアです", profileImageUrl: URL(string: "https://avatars2.githubusercontent.com/u/44288050?v=4")!, itemsCount: 4, followeesCount: 3, followersCount: 3)) }
+
+    // MARK: - Public
+
+    func getItems(page: Int) -> AnyPublisher<[Item], Error> {
+        return Future { $0(.success(Self.items)) }.eraseToAnyPublisher()
+    }
+
+    // FIXME: Optionalやめたい
+    func getItems(with type: SearchType?, page: Int) -> AnyPublisher<[Item], Error> {
+        switch type {
+        case .word:
+            return Future { $0(.success(Self.items)) }.eraseToAnyPublisher()
+
+        case .tag:
+            return Future { $0(.success(Self.items)) }.eraseToAnyPublisher()
+
+        case .none:
+            return getItems(page: page)
+        }
+    }
+
+    // TODO: UserServiceに置く？
+    func getItems(by user: User, page: Int, perPage: Int) -> AnyPublisher<[Item], Error> {
+        return Future { $0(.success(Self.items)) }.eraseToAnyPublisher()
+    }
+
+    func getAuthenticatedUserItems(page: Int, perPage: Int) -> AnyPublisher<[Item], Error> {
+        return Future { $0(.success(Self.items)) }.eraseToAnyPublisher()
+    }
+}


### PR DESCRIPTION
## 概要
- 新着記事一覧を表示するホーム画面を作成
- 記事詳細への遷移と詳細画面も実装

## 実装
- 記事を表示するだけの`ItemListView`を作成
    - `Binding`で記事の配列をもらって表示する
    - ホーム以外でも記事一覧を表示することがあるため
    - 画像表示にはNukeのSwiftUI用のextensionである[FetchImage](https://github.com/kean/FetchImage)を利用
- `HomeView`で`ItemListView`を用いて記事一覧を表示
- 詳細画面は`WebView`を貼り付けただけ
    - `WebView`は`WKWebView`をSwiftUIでラップしたもの

![May-15-2021 07-04-35](https://user-images.githubusercontent.com/44288050/118336232-379b5200-b54c-11eb-89f4-90794aec4475.gif)
