### PR TITLE
プロフィール画面を作成する

### DIFF
--- a/Qiita_SwiftUI.xcodeproj/project.pbxproj
+++ b/Qiita_SwiftUI.xcodeproj/project.pbxproj
@@ -71,6 +71,8 @@
 		E2729DF5264F39DC009473D0 /* StockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DF4264F39DC009473D0 /* StockView.swift */; };
 		E2729DF7264F3A0F009473D0 /* StockViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DF6264F3A0F009473D0 /* StockViewModel.swift */; };
 		E2729DF9264F3ADC009473D0 /* StockStubService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DF8264F3ADC009473D0 /* StockStubService.swift */; };
+		E2BB27692656654400148F45 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BB27682656654400148F45 /* ProfileView.swift */; };
+		E2BB276B2656657500148F45 /* ProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BB276A2656657500148F45 /* ProfileViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -157,6 +159,8 @@
 		E2729DF4264F39DC009473D0 /* StockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockView.swift; sourceTree = "<group>"; };
 		E2729DF6264F3A0F009473D0 /* StockViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockViewModel.swift; sourceTree = "<group>"; };
 		E2729DF8264F3ADC009473D0 /* StockStubService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockStubService.swift; sourceTree = "<group>"; };
+		E2BB27682656654400148F45 /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
+		E2BB276A2656657500148F45 /* ProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -393,6 +397,7 @@
 				E2729DEC264F1582009473D0 /* ItemDetail */,
 				E2729DDF264EC5EC009473D0 /* Home */,
 				E2729DF3264F3998009473D0 /* Stock */,
+				E2BB2767265664AB00148F45 /* Profile */,
 			);
 			path = Screen;
 			sourceTree = "<group>";
@@ -482,6 +487,15 @@
 				E2729DF6264F3A0F009473D0 /* StockViewModel.swift */,
 			);
 			path = Stock;
+			sourceTree = "<group>";
+		};
+		E2BB2767265664AB00148F45 /* Profile */ = {
+			isa = PBXGroup;
+			children = (
+				E2BB27682656654400148F45 /* ProfileView.swift */,
+				E2BB276A2656657500148F45 /* ProfileViewModel.swift */,
+			);
+			path = Profile;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -665,7 +679,9 @@
 				E20DD31325FF403D00735B0A /* VoidModel.swift in Sources */,
 				E20DD38825FF484000735B0A /* Logger.swift in Sources */,
 				E20DD38E25FF48A000735B0A /* URLRequest+.swift in Sources */,
+				E2BB276B2656657500148F45 /* ProfileViewModel.swift in Sources */,
 				E20DD33225FF40FC00735B0A /* UserService.swift in Sources */,
+				E2BB27692656654400148F45 /* ProfileView.swift in Sources */,
 				E20DD34925FF44BA00735B0A /* LoggerPlugin.swift in Sources */,
 				E20DD3BB25FF910E00735B0A /* AuthStubService.swift in Sources */,
 				E20DD35425FF44C600735B0A /* TagTarget.swift in Sources */,

--- a/Qiita_SwiftUI/Presentation/Screen/Launch/LaunchView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Launch/LaunchView.swift
@@ -21,7 +21,7 @@ struct LaunchView: View {
 
     var body: some View {
         if authState.isSignedin {
-            MainView(itemRepository: itemRepository, stockRepository: stockRepository)
+            MainView(authRepository: authRepository, itemRepository: itemRepository, stockRepository: stockRepository)
         } else {
             LoginView(authRepository: authRepository)
         }

--- a/Qiita_SwiftUI/Presentation/Screen/Main/MainView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Main/MainView.swift
@@ -11,6 +11,7 @@ struct MainView: View {
 
     // MARK: - Property
 
+    var authRepository: AuthRepository
     var itemRepository: ItemRepository
     var stockRepository: StockRepository
 
@@ -33,7 +34,7 @@ struct MainView: View {
                     Image(systemName: "folder")
                     Text("Stock")
                 }
-            Text("Profile")
+            ProfileView(authRepository: authRepository, itemRepository: itemRepository)
                 .tabItem {
                     Image(systemName: "person")
                     Text("Profile")
@@ -44,6 +45,6 @@ struct MainView: View {
 
 struct MainView_Previews: PreviewProvider {
     static var previews: some View {
-        MainView(itemRepository: ItemStubService(), stockRepository: StockStubService())
+        MainView(authRepository: AuthStubService(), itemRepository: ItemStubService(), stockRepository: StockStubService())
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/Profile/ProfileView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Profile/ProfileView.swift
@@ -31,7 +31,7 @@ struct ProfileView: View {
                         ItemListView(items: $viewModel.items)
                     }
                 } else {
-                    Text("Loading")
+                    ProgressView()
                 }
             }.navigationBarTitle("Profile", displayMode: .inline)
         }

--- a/Qiita_SwiftUI/Presentation/Screen/Profile/ProfileView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Profile/ProfileView.swift
@@ -1,0 +1,104 @@
+//
+//  ProfileView.swift
+//  Qiita_SwiftUI
+//
+//  Created by kntk on 2021/05/20.
+//
+
+import SwiftUI
+
+struct ProfileView: View {
+
+    // MARK: - Property
+
+    @ObservedObject private var viewModel: ProfileViewModel
+
+    // MARK: - Initializer
+
+    init(authRepository: AuthRepository, itemRepository: ItemRepository) {
+        self.viewModel = ProfileViewModel(authRepository: authRepository, itemRepository: itemRepository)
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        NavigationView {
+            Group {
+                if let user = viewModel.user {
+                    VStack(spacing: 0) {
+                        UserInformationView(user: user)
+
+                        ItemListView(items: $viewModel.items)
+                    }
+                } else {
+                    Text("Loading")
+                }
+            }.navigationBarTitle("Profile", displayMode: .inline)
+        }
+    }
+}
+
+struct UserInformationView: View {
+
+    // MARK: - Property
+
+    var user: User
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(spacing: 8) {
+            VStack(spacing: 4) {
+                ImageView(url: user.profileImageUrl)
+                    .frame(width: 100, height: 100)
+                    .cornerRadius(4.0)
+
+                Text(user.name)
+                    .font(.system(size: 20, weight: .medium))
+
+                Text("@\(user.id)")
+                    .font(.system(size: 17))
+                    .foregroundColor(.secondary)
+
+                Text(user.description ?? " ")
+            }
+
+            VStack(spacing: 2) {
+                HStack(spacing: 0) {
+                    UserContributionView(title: "投稿", count: user.itemsCount)
+                    UserContributionView(title: "フォロー", count: user.followeesCount)
+                    UserContributionView(title: "フォロワー", count: user.followersCount)
+                }
+
+                Divider()
+            }
+        }
+    }
+}
+
+struct UserContributionView: View {
+
+    // MARK: - Property
+
+    var title: String
+    var count: Int
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(spacing: 8) {
+            Text(count.description)
+                .font(.system(size: 16, weight: .medium))
+
+            Text(title)
+                .font(.system(size: 16, weight: .medium))
+                .foregroundColor(.secondary)
+        }.frame(width: 100, height: 60)
+    }
+}
+
+struct ProfileView_Previews: PreviewProvider {
+    static var previews: some View {
+        ProfileView(authRepository: AuthStubService(), itemRepository: ItemStubService())
+    }
+}

--- a/Qiita_SwiftUI/Presentation/Screen/Profile/ProfileViewModel.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Profile/ProfileViewModel.swift
@@ -1,0 +1,64 @@
+//
+//  ProfileViewModel.swift
+//  Qiita_SwiftUI
+//
+//  Created by kntk on 2021/05/20.
+//
+
+import Foundation
+import Combine
+
+final class ProfileViewModel: ObservableObject {
+
+    // MARK: - Property
+
+    @Published var user: User?
+    @Published var items: [Item] = []
+
+    private let authRepository: AuthRepository
+    private let itemRepository: ItemRepository
+    private var cancellables = [AnyCancellable]()
+
+    // MARK: - Initializer
+
+    init(authRepository: AuthRepository, itemRepository: ItemRepository) {
+        self.authRepository = authRepository
+        self.itemRepository = itemRepository
+
+        fetchUser()
+        fetchItems()
+    }
+
+    // MARK: - Public
+
+    func fetchUser() {
+        authRepository.getCurrentUser()
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { completion in
+                switch completion {
+                case .finished:
+                    break
+                case .failure(let error):
+                    Logger.error(error)
+                }
+            }, receiveValue: { user in
+                self.user = user
+            }).store(in: &cancellables)
+    }
+
+    func fetchItems() {
+        itemRepository.getAuthenticatedUserItems(page: 1, perPage: 20)
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { completion in
+                switch completion {
+                case .finished:
+                    break
+                case .failure(let error):
+                    Logger.error(error)
+                }
+            }, receiveValue: { items in
+                self.items = items
+            }).store(in: &cancellables)
+    }
+}
+


### PR DESCRIPTION
## 概要
- プロフィール画面
- ユーザー情報とユーザーの投稿記事

## 実装
- `ProfileView`を作成
    - `authRepository`からユーザー情報を取得
    - `itemRepository`から投稿記事を取得
- `viewModel`での`user`はOptionalにし、取れるまではロード扱いとする
    - ロード中はProgressViewを表示
- Qiitaの新UIに合わせてユーザー情報は縦並べにした

<img width=300 src="https://user-images.githubusercontent.com/44288050/118976475-01c4f600-b9b0-11eb-9b3d-f8ca43dcd924.png">