### PR TITLE
検索画面を実装する

### DIFF
--- a/Qiita_SwiftUI.xcodeproj/project.pbxproj
+++ b/Qiita_SwiftUI.xcodeproj/project.pbxproj
@@ -75,6 +75,9 @@
 		E2BB276B2656657500148F45 /* ProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BB276A2656657500148F45 /* ProfileViewModel.swift */; };
 		E2BB276E2656904100148F45 /* SettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BB276D2656904100148F45 /* SettingView.swift */; };
 		E2BB27702656950700148F45 /* SettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BB276F2656950700148F45 /* SettingViewModel.swift */; };
+		E2BB27732656A8A600148F45 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BB27722656A8A600148F45 /* SearchView.swift */; };
+		E2BB27752656A90100148F45 /* SearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BB27742656A90100148F45 /* SearchViewModel.swift */; };
+		E2BB27772656ACC000148F45 /* TagStubService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BB27762656ACC000148F45 /* TagStubService.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -165,6 +168,9 @@
 		E2BB276A2656657500148F45 /* ProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewModel.swift; sourceTree = "<group>"; };
 		E2BB276D2656904100148F45 /* SettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingView.swift; sourceTree = "<group>"; };
 		E2BB276F2656950700148F45 /* SettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewModel.swift; sourceTree = "<group>"; };
+		E2BB27722656A8A600148F45 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
+		E2BB27742656A90100148F45 /* SearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModel.swift; sourceTree = "<group>"; };
+		E2BB27762656ACC000148F45 /* TagStubService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagStubService.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -400,6 +406,7 @@
 				E2729DE4264ECD8C009473D0 /* ItemList */,
 				E2729DEC264F1582009473D0 /* ItemDetail */,
 				E2729DDF264EC5EC009473D0 /* Home */,
+				E2BB27712656A88C00148F45 /* Search */,
 				E2729DF3264F3998009473D0 /* Stock */,
 				E2BB2767265664AB00148F45 /* Profile */,
 				E2BB276C26568F8F00148F45 /* Setting */,
@@ -446,6 +453,7 @@
 				E20DD3BA25FF910E00735B0A /* AuthStubService.swift */,
 				E2729DF1264F24F8009473D0 /* ItemStubService.swift */,
 				E2729DF8264F3ADC009473D0 /* StockStubService.swift */,
+				E2BB27762656ACC000148F45 /* TagStubService.swift */,
 			);
 			path = Stub;
 			sourceTree = "<group>";
@@ -510,6 +518,15 @@
 				E2BB276F2656950700148F45 /* SettingViewModel.swift */,
 			);
 			path = Setting;
+			sourceTree = "<group>";
+		};
+		E2BB27712656A88C00148F45 /* Search */ = {
+			isa = PBXGroup;
+			children = (
+				E2BB27722656A8A600148F45 /* SearchView.swift */,
+				E2BB27742656A90100148F45 /* SearchViewModel.swift */,
+			);
+			path = Search;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -671,6 +688,7 @@
 				E2729DEB264F0D43009473D0 /* ImageView.swift in Sources */,
 				E20DD31725FF403D00735B0A /* ItemTag.swift in Sources */,
 				E20DD3A825FF8FE400735B0A /* LaunchView.swift in Sources */,
+				E2BB27752656A90100148F45 /* SearchViewModel.swift in Sources */,
 				E20DD33725FF40FC00735B0A /* TagService.swift in Sources */,
 				E20DD34825FF44BA00735B0A /* Auth.swift in Sources */,
 				E20DD33325FF40FC00735B0A /* LikeService.swift in Sources */,
@@ -694,10 +712,12 @@
 				E20DD39325FF802900735B0A /* URL+.swift in Sources */,
 				E20DD31325FF403D00735B0A /* VoidModel.swift in Sources */,
 				E20DD38825FF484000735B0A /* Logger.swift in Sources */,
+				E2BB27732656A8A600148F45 /* SearchView.swift in Sources */,
 				E20DD38E25FF48A000735B0A /* URLRequest+.swift in Sources */,
 				E2BB276B2656657500148F45 /* ProfileViewModel.swift in Sources */,
 				E20DD33225FF40FC00735B0A /* UserService.swift in Sources */,
 				E2BB27692656654400148F45 /* ProfileView.swift in Sources */,
+				E2BB27772656ACC000148F45 /* TagStubService.swift in Sources */,
 				E20DD34925FF44BA00735B0A /* LoggerPlugin.swift in Sources */,
 				E20DD3BB25FF910E00735B0A /* AuthStubService.swift in Sources */,
 				E20DD35425FF44C600735B0A /* TagTarget.swift in Sources */,

--- a/Qiita_SwiftUI.xcodeproj/project.pbxproj
+++ b/Qiita_SwiftUI.xcodeproj/project.pbxproj
@@ -79,6 +79,8 @@
 		E2BB27752656A90100148F45 /* SearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BB27742656A90100148F45 /* SearchViewModel.swift */; };
 		E2BB27772656ACC000148F45 /* TagStubService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BB27762656ACC000148F45 /* TagStubService.swift */; };
 		E2BB277C2656B92100148F45 /* SwiftUIX in Frameworks */ = {isa = PBXBuildFile; productRef = E2BB277B2656B92100148F45 /* SwiftUIX */; };
+		E2BB277F2656C2CB00148F45 /* SearchResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BB277E2656C2CB00148F45 /* SearchResultView.swift */; };
+		E2BB27812656C3E400148F45 /* SearchResultViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BB27802656C3E400148F45 /* SearchResultViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -172,6 +174,8 @@
 		E2BB27722656A8A600148F45 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
 		E2BB27742656A90100148F45 /* SearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModel.swift; sourceTree = "<group>"; };
 		E2BB27762656ACC000148F45 /* TagStubService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagStubService.swift; sourceTree = "<group>"; };
+		E2BB277E2656C2CB00148F45 /* SearchResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultView.swift; sourceTree = "<group>"; };
+		E2BB27802656C3E400148F45 /* SearchResultViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -409,6 +413,7 @@
 				E2729DEC264F1582009473D0 /* ItemDetail */,
 				E2729DDF264EC5EC009473D0 /* Home */,
 				E2BB27712656A88C00148F45 /* Search */,
+				E2BB277D2656C26D00148F45 /* SearchResult */,
 				E2729DF3264F3998009473D0 /* Stock */,
 				E2BB2767265664AB00148F45 /* Profile */,
 				E2BB276C26568F8F00148F45 /* Setting */,
@@ -529,6 +534,15 @@
 				E2BB27742656A90100148F45 /* SearchViewModel.swift */,
 			);
 			path = Search;
+			sourceTree = "<group>";
+		};
+		E2BB277D2656C26D00148F45 /* SearchResult */ = {
+			isa = PBXGroup;
+			children = (
+				E2BB277E2656C2CB00148F45 /* SearchResultView.swift */,
+				E2BB27802656C3E400148F45 /* SearchResultViewModel.swift */,
+			);
+			path = SearchResult;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -676,6 +690,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E20DD33425FF40FC00735B0A /* ItemService.swift in Sources */,
+				E2BB277F2656C2CB00148F45 /* SearchResultView.swift in Sources */,
 				E20DD34525FF44BA00735B0A /* BaseTarget.swift in Sources */,
 				E20DD30925FF3EAA00735B0A /* AppEnvironment.swift in Sources */,
 				E20DD35125FF44C600735B0A /* UserTarget.swift in Sources */,
@@ -697,6 +712,7 @@
 				E20DD34825FF44BA00735B0A /* Auth.swift in Sources */,
 				E20DD33325FF40FC00735B0A /* LikeService.swift in Sources */,
 				E20DD30725FF3EAA00735B0A /* AppContext.swift in Sources */,
+				E2BB27812656C3E400148F45 /* SearchResultViewModel.swift in Sources */,
 				E20DD32425FF40EE00735B0A /* LikeRepository.swift in Sources */,
 				E2729DEE264F15C4009473D0 /* ItemDetailView.swift in Sources */,
 				E2729DF5264F39DC009473D0 /* StockView.swift in Sources */,

--- a/Qiita_SwiftUI.xcodeproj/project.pbxproj
+++ b/Qiita_SwiftUI.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		E2BB27732656A8A600148F45 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BB27722656A8A600148F45 /* SearchView.swift */; };
 		E2BB27752656A90100148F45 /* SearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BB27742656A90100148F45 /* SearchViewModel.swift */; };
 		E2BB27772656ACC000148F45 /* TagStubService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BB27762656ACC000148F45 /* TagStubService.swift */; };
+		E2BB277C2656B92100148F45 /* SwiftUIX in Frameworks */ = {isa = PBXBuildFile; productRef = E2BB277B2656B92100148F45 /* SwiftUIX */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -181,6 +182,7 @@
 				E20DD37D25FF47E600735B0A /* KeychainAccess in Frameworks */,
 				E20DD36425FF460500735B0A /* Moya in Frameworks */,
 				E20DD38325FF483200735B0A /* SwiftyBeaver in Frameworks */,
+				E2BB277C2656B92100148F45 /* SwiftUIX in Frameworks */,
 				E2729DE9264F0C82009473D0 /* FetchImage in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -550,6 +552,7 @@
 				E20DD37C25FF47E600735B0A /* KeychainAccess */,
 				E20DD38225FF483200735B0A /* SwiftyBeaver */,
 				E2729DE8264F0C82009473D0 /* FetchImage */,
+				E2BB277B2656B92100148F45 /* SwiftUIX */,
 			);
 			productName = Qiita_SwiftUI;
 			productReference = E20DD2BF25FF325600735B0A /* Qiita_SwiftUI.app */;
@@ -627,6 +630,7 @@
 				E20DD37B25FF47E600735B0A /* XCRemoteSwiftPackageReference "KeychainAccess" */,
 				E20DD38125FF483200735B0A /* XCRemoteSwiftPackageReference "SwiftyBeaver" */,
 				E2729DE7264F0C82009473D0 /* XCRemoteSwiftPackageReference "FetchImage" */,
+				E2BB277A2656B92100148F45 /* XCRemoteSwiftPackageReference "SwiftUIX" */,
 			);
 			productRefGroup = E20DD2C025FF325600735B0A /* Products */;
 			projectDirPath = "";
@@ -1084,6 +1088,14 @@
 				minimumVersion = 0.4.0;
 			};
 		};
+		E2BB277A2656B92100148F45 /* XCRemoteSwiftPackageReference "SwiftUIX" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/SwiftUIX/SwiftUIX.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.0.6;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1106,6 +1118,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = E2729DE7264F0C82009473D0 /* XCRemoteSwiftPackageReference "FetchImage" */;
 			productName = FetchImage;
+		};
+		E2BB277B2656B92100148F45 /* SwiftUIX */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E2BB277A2656B92100148F45 /* XCRemoteSwiftPackageReference "SwiftUIX" */;
+			productName = SwiftUIX;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Qiita_SwiftUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Qiita_SwiftUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -128,6 +128,15 @@
         }
       },
       {
+        "package": "SwiftUIX",
+        "repositoryURL": "https://github.com/SwiftUIX/SwiftUIX.git",
+        "state": {
+          "branch": null,
+          "revision": "e0fd9ff48354a447d5dccdb4b485a69b63688e48",
+          "version": "0.0.6"
+        }
+      },
+      {
         "package": "SwiftyBeaver",
         "repositoryURL": "https://github.com/SwiftyBeaver/SwiftyBeaver.git",
         "state": {

--- a/Qiita_SwiftUI/Presentation/Common/ImageView.swift
+++ b/Qiita_SwiftUI/Presentation/Common/ImageView.swift
@@ -15,10 +15,10 @@ struct ImageView: View {
 
     var body: some View {
         ZStack {
-            Rectangle().fill(Color.gray)
+            Rectangle().fill(Color.systemBackground)
             image.view?
                 .resizable()
-                .aspectRatio(contentMode: .fill)
+                .aspectRatio(contentMode: .fit)
                 .clipped()
         }
         .onAppear { image.load(url) }

--- a/Qiita_SwiftUI/Presentation/Screen/Launch/LaunchView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Launch/LaunchView.swift
@@ -15,13 +15,14 @@ struct LaunchView: View {
 
     let authRepository: AuthRepository
     let itemRepository: ItemRepository
-    var stockRepository: StockRepository
+    let stockRepository: StockRepository
+    let tagRepository: TagRepository
 
     // MARK: - Body
 
     var body: some View {
         if authState.isSignedin {
-            MainView(authRepository: authRepository, itemRepository: itemRepository, stockRepository: stockRepository)
+            MainView(authRepository: authRepository, itemRepository: itemRepository, stockRepository: stockRepository, tagRepository: tagRepository)
         } else {
             LoginView(authRepository: authRepository)
         }
@@ -30,7 +31,7 @@ struct LaunchView: View {
 
 struct LaunchView_Previews: PreviewProvider {
     static var previews: some View {
-        LaunchView(authRepository: AuthStubService(), itemRepository: ItemStubService(), stockRepository: StockStubService())
+        LaunchView(authRepository: AuthStubService(), itemRepository: ItemStubService(), stockRepository: StockStubService(), tagRepository: TagStubService())
             .environmentObject(AuthState(authRepository: AuthStubService()))
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/Main/MainView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Main/MainView.swift
@@ -14,6 +14,7 @@ struct MainView: View {
     var authRepository: AuthRepository
     var itemRepository: ItemRepository
     var stockRepository: StockRepository
+    var tagRepository: TagRepository
 
     // MARK: - Body
 
@@ -24,7 +25,7 @@ struct MainView: View {
                     Image(systemName: "house")
                     Text("Home")
                 }
-            Text("Search")
+            SearchView(tagRepository: tagRepository)
                 .tabItem {
                     Image(systemName: "magnifyingglass")
                     Text("Search")
@@ -45,6 +46,6 @@ struct MainView: View {
 
 struct MainView_Previews: PreviewProvider {
     static var previews: some View {
-        MainView(authRepository: AuthStubService(), itemRepository: ItemStubService(), stockRepository: StockStubService())
+        MainView(authRepository: AuthStubService(), itemRepository: ItemStubService(), stockRepository: StockStubService(), tagRepository: TagStubService())
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/Main/MainView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Main/MainView.swift
@@ -25,7 +25,7 @@ struct MainView: View {
                     Image(systemName: "house")
                     Text("Home")
                 }
-            SearchView(tagRepository: tagRepository)
+            SearchView(tagRepository: tagRepository, itemRepository: itemRepository)
                 .tabItem {
                     Image(systemName: "magnifyingglass")
                     Text("Search")

--- a/Qiita_SwiftUI/Presentation/Screen/Search/SearchView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Search/SearchView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import SwiftUIX
 
 struct SearchView: View {
 
@@ -13,7 +14,10 @@ struct SearchView: View {
 
     @ObservedObject private var viewModel: SearchViewModel
 
-    @State private var seachText: String = ""
+    @State var isEditing: Bool = false
+    @State private var searchText: String = ""
+
+    @State private var isPush: Bool = false
 
     // MARK: - Initializer
 
@@ -29,7 +33,12 @@ struct SearchView: View {
                 ForEach(viewModel.tags) { tag in
                     Text(tag.id)
                 }
-            }.navigationBarItems(leading: TextField("キーワード検索", text: $seachText), trailing: Button("キャンセル", action: { }))
+            }.navigationBarTitle("Search", displayMode: .inline)
+            .navigationSearchBar {
+                SearchBar("キーワード検索", text: $searchText, isEditing: $isEditing, onCommit: { isPush.toggle() })
+                    .showsCancelButton(isEditing)
+
+            }
         }
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/Search/SearchView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Search/SearchView.swift
@@ -32,10 +32,22 @@ struct SearchView: View {
     var body: some View {
         NavigationView {
             VStack {
-                List {
-                    ForEach(viewModel.tags) { tag in
-                        Text(tag.id)
-                    }
+                GeometryReader { geometry in
+                    CollectionView(viewModel.tags) { tag in
+                        ZStack {
+                            ImageView(url: tag.iconUrl!)
+
+                            Color(.darkText.withAlphaComponent(0.2))
+
+                            Text(tag.id)
+                                .foregroundColor(.white)
+                                .font(.system(size: 17, weight: .semibold))
+
+                        }
+                        // geometryが一瞬0.0等を返す場合があるので、その時に-にならないようにする
+                        .frame(width: max(0.0, (geometry.size.width - 2) / 3), height: max(0.0, (geometry.size.width - 2) / 3))
+                        // なんか1.0だとレイアウトが崩れる(小数演算の問題か)
+                    }.collectionViewLayout(FlowCollectionViewLayout(minimumLineSpacing: 1, minimumInteritemSpacing: 0.99))
                 }
                 NavigationLink(destination: SearchResultView(searchWord: searchText, itemRepository: itemRepository), isActive: $isPush) { EmptyView() }
                     .navigationBarTitle("Search", displayMode: .inline)

--- a/Qiita_SwiftUI/Presentation/Screen/Search/SearchView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Search/SearchView.swift
@@ -32,24 +32,9 @@ struct SearchView: View {
     var body: some View {
         NavigationView {
             VStack {
-                GeometryReader { geometry in
-                    CollectionView(viewModel.tags) { tag in
-                        ZStack {
-                            ImageView(url: tag.iconUrl!)
+                TagListView(tags: viewModel.tags, itemRepository: itemRepository)
 
-                            Color(.darkText.withAlphaComponent(0.2))
-
-                            Text(tag.id)
-                                .foregroundColor(.white)
-                                .font(.system(size: 17, weight: .semibold))
-
-                        }
-                        // geometryが一瞬0.0等を返す場合があるので、その時に-にならないようにする
-                        .frame(width: max(0.0, (geometry.size.width - 2) / 3), height: max(0.0, (geometry.size.width - 2) / 3))
-                        // なんか1.0だとレイアウトが崩れる(小数演算の問題か)
-                    }.collectionViewLayout(FlowCollectionViewLayout(minimumLineSpacing: 1, minimumInteritemSpacing: 0.99))
-                }
-                NavigationLink(destination: SearchResultView(searchWord: searchText, itemRepository: itemRepository), isActive: $isPush) { EmptyView() }
+                NavigationLink(destination: SearchResultView(searchType: .word(searchText), itemRepository: itemRepository), isActive: $isPush) { EmptyView() }
                     .navigationBarTitle("Search", displayMode: .inline)
                     .navigationSearchBar {
                         SearchBar("キーワード検索", text: $searchText, isEditing: $isEditing, onCommit: { isPush.toggle() })
@@ -57,6 +42,34 @@ struct SearchView: View {
 
                 }
             }
+        }
+    }
+}
+
+struct TagListView: View {
+
+    let tags: [ItemTag]
+    let itemRepository: ItemRepository
+
+    var body: some View {
+        GeometryReader { geometry in
+            CollectionView(tags) { tag in
+                NavigationLink(destination: SearchResultView(searchType: .tag(tag), itemRepository: itemRepository)) {
+                    ZStack {
+                        ImageView(url: tag.iconUrl!)
+
+                        Color(.darkText.withAlphaComponent(0.2))
+
+                        Text(tag.id)
+                            .foregroundColor(.white)
+                            .font(.system(size: 17, weight: .semibold))
+
+                    }
+                    // geometryが一瞬0.0等を返す場合があるので、その時に-にならないようにする
+                    .frame(width: max(0.0, (geometry.size.width - 2) / 3), height: max(0.0, (geometry.size.width - 2) / 3))
+                    // なんか1.0だとレイアウトが崩れる(小数演算の問題か)
+                }
+            }.collectionViewLayout(FlowCollectionViewLayout(minimumLineSpacing: 1, minimumInteritemSpacing: 0.99))
         }
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/Search/SearchView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Search/SearchView.swift
@@ -1,0 +1,41 @@
+//
+//  SearchView.swift
+//  Qiita_SwiftUI
+//
+//  Created by kntk on 2021/05/20.
+//
+
+import SwiftUI
+
+struct SearchView: View {
+
+    // MARK: - Property
+
+    @ObservedObject private var viewModel: SearchViewModel
+
+    @State private var seachText: String = ""
+
+    // MARK: - Initializer
+
+    init(tagRepository: TagRepository) {
+        self.viewModel = SearchViewModel(tagRepository: tagRepository)
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        NavigationView {
+            List {
+                ForEach(viewModel.tags) { tag in
+                    Text(tag.id)
+                }
+            }.navigationBarItems(leading: TextField("キーワード検索", text: $seachText), trailing: Button("キャンセル", action: { }))
+        }
+    }
+}
+
+struct SearchView_Previews: PreviewProvider {
+    static var previews: some View {
+        SearchView(tagRepository: TagStubService())
+    }
+}

--- a/Qiita_SwiftUI/Presentation/Screen/Search/SearchView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Search/SearchView.swift
@@ -12,6 +12,7 @@ struct SearchView: View {
 
     // MARK: - Property
 
+    private let itemRepository: ItemRepository
     @ObservedObject private var viewModel: SearchViewModel
 
     @State var isEditing: Bool = false
@@ -21,23 +22,28 @@ struct SearchView: View {
 
     // MARK: - Initializer
 
-    init(tagRepository: TagRepository) {
+    init(tagRepository: TagRepository, itemRepository: ItemRepository) {
         self.viewModel = SearchViewModel(tagRepository: tagRepository)
+        self.itemRepository = itemRepository
     }
 
     // MARK: - Body
 
     var body: some View {
         NavigationView {
-            List {
-                ForEach(viewModel.tags) { tag in
-                    Text(tag.id)
+            VStack {
+                List {
+                    ForEach(viewModel.tags) { tag in
+                        Text(tag.id)
+                    }
                 }
-            }.navigationBarTitle("Search", displayMode: .inline)
-            .navigationSearchBar {
-                SearchBar("キーワード検索", text: $searchText, isEditing: $isEditing, onCommit: { isPush.toggle() })
-                    .showsCancelButton(isEditing)
+                NavigationLink(destination: SearchResultView(searchWord: searchText, itemRepository: itemRepository), isActive: $isPush) { EmptyView() }
+                    .navigationBarTitle("Search", displayMode: .inline)
+                    .navigationSearchBar {
+                        SearchBar("キーワード検索", text: $searchText, isEditing: $isEditing, onCommit: { isPush.toggle() })
+                            .showsCancelButton(isEditing)
 
+                }
             }
         }
     }
@@ -45,6 +51,6 @@ struct SearchView: View {
 
 struct SearchView_Previews: PreviewProvider {
     static var previews: some View {
-        SearchView(tagRepository: TagStubService())
+        SearchView(tagRepository: TagStubService(), itemRepository: ItemStubService())
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/Search/SearchViewModel.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Search/SearchViewModel.swift
@@ -1,0 +1,45 @@
+//
+//  SearchViewModel.swift
+//  Qiita_SwiftUI
+//
+//  Created by kntk on 2021/05/20.
+//
+
+import Foundation
+import Combine
+
+final class SearchViewModel: ObservableObject {
+
+    // MARK: - Property
+
+    @Published var tags: [ItemTag] = []
+
+    private let tagRepository: TagRepository
+    private var cancellables = [AnyCancellable]()
+
+    // MARK: - Initializer
+
+    init(tagRepository: TagRepository) {
+        self.tagRepository = tagRepository
+
+        fetchTags()
+    }
+
+    // MARK: - Public
+
+    func fetchTags() {
+        tagRepository.getTags(page: 1, perPage: 20, sort: "count")
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { completion in
+                switch completion {
+                case .finished:
+                    break
+                case .failure(let error):
+                    Logger.error(error)
+                }
+            }, receiveValue: { tags in
+                self.tags = tags
+            }).store(in: &cancellables)
+    }
+}
+

--- a/Qiita_SwiftUI/Presentation/Screen/Search/SearchViewModel.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Search/SearchViewModel.swift
@@ -28,7 +28,7 @@ final class SearchViewModel: ObservableObject {
     // MARK: - Public
 
     func fetchTags() {
-        tagRepository.getTags(page: 1, perPage: 20, sort: "count")
+        tagRepository.getTags(page: 1, perPage: 30, sort: "count")
             .receive(on: DispatchQueue.main)
             .sink(receiveCompletion: { completion in
                 switch completion {

--- a/Qiita_SwiftUI/Presentation/Screen/SearchResult/SearchResultView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/SearchResult/SearchResultView.swift
@@ -15,20 +15,27 @@ struct SearchResultView: View {
 
     // MARK: - Initializer
 
-    init(searchWord: String, itemRepository: ItemRepository) {
-        viewModel = SearchResultViewModel(searchWord: searchWord, itemRepository: itemRepository)
+    init(searchType: SearchType, itemRepository: ItemRepository) {
+        viewModel = SearchResultViewModel(searchType: searchType, itemRepository: itemRepository)
     }
 
     // MARK: - Body
 
     var body: some View {
         ItemListView(items: $viewModel.items)
-            .navigationTitle("キーワード: \(viewModel.searchWord)")
+            .navigationTitle(navigationTitle)
+    }
+
+    var navigationTitle: String {
+        switch viewModel.searchType {
+        case .tag(let tag): return "タグ: \(tag.id)"
+        case .word(let word): return "キーワード: \(word)"
+        }
     }
 }
 
 struct SearchResultView_Previews: PreviewProvider {
     static var previews: some View {
-        SearchResultView(searchWord: "iOS", itemRepository: ItemStubService())
+        SearchResultView(searchType: .word("iOS"), itemRepository: ItemStubService())
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/SearchResult/SearchResultView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/SearchResult/SearchResultView.swift
@@ -1,0 +1,34 @@
+//
+//  SearchResultView.swift
+//  Qiita_SwiftUI
+//
+//  Created by kntk on 2021/05/21.
+//
+
+import SwiftUI
+
+struct SearchResultView: View {
+
+    // MARK: - Property
+
+    @ObservedObject private var viewModel: SearchResultViewModel
+
+    // MARK: - Initializer
+
+    init(searchWord: String, itemRepository: ItemRepository) {
+        viewModel = SearchResultViewModel(searchWord: searchWord, itemRepository: itemRepository)
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        ItemListView(items: $viewModel.items)
+            .navigationTitle("キーワード: \(viewModel.searchWord)")
+    }
+}
+
+struct SearchResultView_Previews: PreviewProvider {
+    static var previews: some View {
+        SearchResultView(searchWord: "iOS", itemRepository: ItemStubService())
+    }
+}

--- a/Qiita_SwiftUI/Presentation/Screen/SearchResult/SearchResultViewModel.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/SearchResult/SearchResultViewModel.swift
@@ -1,0 +1,47 @@
+//
+//  SearchResultViewModel.swift
+//  Qiita_SwiftUI
+//
+//  Created by kntk on 2021/05/21.
+//
+
+import Foundation
+import Combine
+
+final class SearchResultViewModel: ObservableObject {
+
+    // MARK: - Property
+
+    @Published var items: [Item] = []
+    let searchWord: String
+
+    private let itemRepository: ItemRepository
+    private var cancellables = [AnyCancellable]()
+
+    // MARK: - Initializer
+
+    init(searchWord: String, itemRepository: ItemRepository) {
+        self.searchWord = searchWord
+        self.itemRepository = itemRepository
+
+        fetchItems()
+    }
+
+    // MARK: - Public
+
+    func fetchItems() {
+        itemRepository.getItems(with: .word(searchWord), page: 1)
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { completion in
+                switch completion {
+                case .finished:
+                    break
+                case .failure(let error):
+                    Logger.error(error)
+                }
+            }, receiveValue: { items in
+                self.items = items
+            }).store(in: &cancellables)
+    }
+}
+

--- a/Qiita_SwiftUI/Presentation/Screen/SearchResult/SearchResultViewModel.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/SearchResult/SearchResultViewModel.swift
@@ -13,15 +13,15 @@ final class SearchResultViewModel: ObservableObject {
     // MARK: - Property
 
     @Published var items: [Item] = []
-    let searchWord: String
+    let searchType: SearchType
 
     private let itemRepository: ItemRepository
     private var cancellables = [AnyCancellable]()
 
     // MARK: - Initializer
 
-    init(searchWord: String, itemRepository: ItemRepository) {
-        self.searchWord = searchWord
+    init(searchType: SearchType, itemRepository: ItemRepository) {
+        self.searchType = searchType
         self.itemRepository = itemRepository
 
         fetchItems()
@@ -30,7 +30,7 @@ final class SearchResultViewModel: ObservableObject {
     // MARK: - Public
 
     func fetchItems() {
-        itemRepository.getItems(with: .word(searchWord), page: 1)
+        itemRepository.getItems(with: searchType, page: 1)
             .receive(on: DispatchQueue.main)
             .sink(receiveCompletion: { completion in
                 switch completion {

--- a/Qiita_SwiftUI/Qiita_SwiftUIApp.swift
+++ b/Qiita_SwiftUI/Qiita_SwiftUIApp.swift
@@ -12,7 +12,7 @@ struct Qiita_SwiftUIApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     var body: some Scene {
         WindowGroup {
-            LaunchView(authRepository: AppContainer.shared.authRepository, itemRepository: AppContainer.shared.itemRepository, stockRepository: AppContainer.shared.stockRepository)
+            LaunchView(authRepository: AppContainer.shared.authRepository, itemRepository: AppContainer.shared.itemRepository, stockRepository: AppContainer.shared.stockRepository, tagRepository: AppContainer.shared.tagRepository)
                 .environmentObject(AuthState(authRepository: AppContainer.shared.authRepository))
         }
     }

--- a/Qiita_SwiftUI/Service/Stub/TagStubService.swift
+++ b/Qiita_SwiftUI/Service/Stub/TagStubService.swift
@@ -1,0 +1,30 @@
+//
+//  TagStubService.swift
+//  Qiita_SwiftUI
+//
+//  Created by kntk on 2021/05/20.
+//
+
+import Foundation
+import Combine
+
+final class TagStubService: TagRepository {
+
+    private let tags: [ItemTag] = []
+
+    func getTags(page: Int, perPage: Int, sort: String) -> AnyPublisher<[ItemTag], Error> {
+        return Future { $0(.success(self.tags)) }.eraseToAnyPublisher()
+    }
+
+    func follow(id: ItemTag.ID) -> AnyPublisher<VoidModel, Error> {
+        return Future { $0(.success(VoidModel())) }.eraseToAnyPublisher()
+    }
+
+    func unfollow(id: ItemTag.ID) -> AnyPublisher<VoidModel, Error> {
+        return Future { $0(.success(VoidModel())) }.eraseToAnyPublisher()
+    }
+
+    func checkIsFollowed(id: ItemTag.ID) -> AnyPublisher<VoidModel, Error> {
+        return Future { $0(.success(VoidModel())) }.eraseToAnyPublisher()
+    }
+}

--- a/Qiita_SwiftUI/Service/Stub/TagStubService.swift
+++ b/Qiita_SwiftUI/Service/Stub/TagStubService.swift
@@ -10,7 +10,15 @@ import Combine
 
 final class TagStubService: TagRepository {
 
-    private let tags: [ItemTag] = []
+    private let tags: [ItemTag] = [
+        ItemTag(iconUrl: URL(string: "https://avatars2.githubusercontent.com/u/44288050?v=4")!, followersCount: 10, id: "python", itemsCount: 10),
+        ItemTag(iconUrl: URL(string: "https://avatars2.githubusercontent.com/u/44288050?v=4")!, followersCount: 10, id: "iOS", itemsCount: 10),
+        ItemTag(iconUrl: URL(string: "https://avatars2.githubusercontent.com/u/44288050?v=4")!, followersCount: 10, id: "Swift", itemsCount: 10),
+        ItemTag(iconUrl: URL(string: "https://avatars2.githubusercontent.com/u/44288050?v=4")!, followersCount: 10, id: "Android", itemsCount: 10),
+        ItemTag(iconUrl: URL(string: "https://avatars2.githubusercontent.com/u/44288050?v=4")!, followersCount: 10, id: "Kotlin", itemsCount: 10),
+        ItemTag(iconUrl: URL(string: "https://avatars2.githubusercontent.com/u/44288050?v=4")!, followersCount: 10, id: "Java", itemsCount: 10),
+        ItemTag(iconUrl: URL(string: "https://avatars2.githubusercontent.com/u/44288050?v=4")!, followersCount: 10, id: "Ruby", itemsCount: 10)
+    ]
 
     func getTags(page: Int, perPage: Int, sort: String) -> AnyPublisher<[ItemTag], Error> {
         return Future { $0(.success(self.tags)) }.eraseToAnyPublisher()


### PR DESCRIPTION
## 概要
- 検索画面
- 検索バーでキーワード検索
- CollectionViewでタグ一覧を表示してタップでタグ検索

## 実装
- SwiftUIXを導入
    - SwiftUIにSearchBar, CollectionViewがないため
- SearchViewのNavigationにSearchBarを追加
    - `State searchText`をSearchBarにbind
    - SearchBarのキーボードの検索ボタンをタッチで`SearchResultView`へ遷移
    - `EmptyView`が中身の`NavigationLink(isActive: )`を利用することでアクション風に遷移できる
- CollectionViewでタグ一覧を表示
    - 画面幅を取るために`GeometryReader`を利用する
- `SearchResultView`はSearchViewからwordもしくはtagを貰い、それを元に記事取得APIを叩く

| キーワード検索 | タグ検索 |
| ------ | ------ |
| ![May-21-2021 13-55-40](https://user-images.githubusercontent.com/44288050/119084172-45654180-ba3c-11eb-9c99-3500945f1741.gif)| ![May-21-2021 13-53-59](https://user-images.githubusercontent.com/44288050/119084239-62017980-ba3c-11eb-97fa-58c1133f73c8.gif) |