### PR TITLE
プルリフを追加

### DIFF
--- a/Qiita_SwiftUI.xcodeproj/project.pbxproj
+++ b/Qiita_SwiftUI.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		E2729DF5264F39DC009473D0 /* StockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DF4264F39DC009473D0 /* StockView.swift */; };
 		E2729DF7264F3A0F009473D0 /* StockViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DF6264F3A0F009473D0 /* StockViewModel.swift */; };
 		E2729DF9264F3ADC009473D0 /* StockStubService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DF8264F3ADC009473D0 /* StockStubService.swift */; };
+		E295D60B26D8AE4300246986 /* SwiftUIRefresh in Frameworks */ = {isa = PBXBuildFile; productRef = E295D60A26D8AE4300246986 /* SwiftUIRefresh */; };
 		E2BB27692656654400148F45 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BB27682656654400148F45 /* ProfileView.swift */; };
 		E2BB276B2656657500148F45 /* ProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BB276A2656657500148F45 /* ProfileViewModel.swift */; };
 		E2BB276E2656904100148F45 /* SettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BB276D2656904100148F45 /* SettingView.swift */; };
@@ -183,6 +184,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E295D60B26D8AE4300246986 /* SwiftUIRefresh in Frameworks */,
 				E20DD37D25FF47E600735B0A /* KeychainAccess in Frameworks */,
 				E20DD36425FF460500735B0A /* Moya in Frameworks */,
 				E20DD38325FF483200735B0A /* SwiftyBeaver in Frameworks */,
@@ -567,6 +569,7 @@
 				E20DD38225FF483200735B0A /* SwiftyBeaver */,
 				E2729DE8264F0C82009473D0 /* FetchImage */,
 				E2BB277B2656B92100148F45 /* SwiftUIX */,
+				E295D60A26D8AE4300246986 /* SwiftUIRefresh */,
 			);
 			productName = Qiita_SwiftUI;
 			productReference = E20DD2BF25FF325600735B0A /* Qiita_SwiftUI.app */;
@@ -645,6 +648,7 @@
 				E20DD38125FF483200735B0A /* XCRemoteSwiftPackageReference "SwiftyBeaver" */,
 				E2729DE7264F0C82009473D0 /* XCRemoteSwiftPackageReference "FetchImage" */,
 				E2BB277A2656B92100148F45 /* XCRemoteSwiftPackageReference "SwiftUIX" */,
+				E295D60926D8AE4300246986 /* XCRemoteSwiftPackageReference "SwiftUIRefresh" */,
 			);
 			productRefGroup = E20DD2C025FF325600735B0A /* Products */;
 			projectDirPath = "";
@@ -1104,6 +1108,14 @@
 				minimumVersion = 0.4.0;
 			};
 		};
+		E295D60926D8AE4300246986 /* XCRemoteSwiftPackageReference "SwiftUIRefresh" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/siteline/SwiftUIRefresh.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.0.3;
+			};
+		};
 		E2BB277A2656B92100148F45 /* XCRemoteSwiftPackageReference "SwiftUIX" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SwiftUIX/SwiftUIX.git";
@@ -1134,6 +1146,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = E2729DE7264F0C82009473D0 /* XCRemoteSwiftPackageReference "FetchImage" */;
 			productName = FetchImage;
+		};
+		E295D60A26D8AE4300246986 /* SwiftUIRefresh */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E295D60926D8AE4300246986 /* XCRemoteSwiftPackageReference "SwiftUIRefresh" */;
+			productName = SwiftUIRefresh;
 		};
 		E2BB277B2656B92100148F45 /* SwiftUIX */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Qiita_SwiftUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Qiita_SwiftUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -128,6 +128,24 @@
         }
       },
       {
+        "package": "Introspect",
+        "repositoryURL": "https://github.com/siteline/SwiftUI-Introspect.git",
+        "state": {
+          "branch": null,
+          "revision": "2e09be8af614401bc9f87d40093ec19ce56ccaf2",
+          "version": "0.1.3"
+        }
+      },
+      {
+        "package": "SwiftUIRefresh",
+        "repositoryURL": "https://github.com/siteline/SwiftUIRefresh.git",
+        "state": {
+          "branch": null,
+          "revision": "fa8fac7b5eb5c729983a8bef65f094b5e0d12014",
+          "version": "0.0.3"
+        }
+      },
+      {
         "package": "SwiftUIX",
         "repositoryURL": "https://github.com/SwiftUIX/SwiftUIX.git",
         "state": {

--- a/Qiita_SwiftUI/Presentation/Screen/Home/HomeView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Home/HomeView.swift
@@ -23,7 +23,7 @@ struct HomeView: View {
 
     var body: some View {
         NavigationView {
-            ItemListView(items: $viewModel.items)
+            ItemListView(items: $viewModel.items, isRefreshing: $viewModel.isRefreshing, onRefresh: viewModel.fetchItems)
                 .navigationBarTitle("Home", displayMode: .inline)
         }
     }

--- a/Qiita_SwiftUI/Presentation/Screen/Home/HomeViewModel.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Home/HomeViewModel.swift
@@ -13,6 +13,7 @@ final class HomeViewModel: ObservableObject {
     // MARK: - Property
 
     @Published var items: [Item] = []
+    @Published var isRefreshing = false
 
     private let itemRepository: ItemRepository
     private var cancellables = [AnyCancellable]()
@@ -31,6 +32,7 @@ final class HomeViewModel: ObservableObject {
         itemRepository.getItems(page: 1)
             .receive(on: DispatchQueue.main)
             .sink(receiveCompletion: { completion in
+                self.isRefreshing = false
                 switch completion {
                 case .finished:
                     break

--- a/Qiita_SwiftUI/Presentation/Screen/ItemList/ItemListView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/ItemList/ItemListView.swift
@@ -6,12 +6,16 @@
 //
 
 import SwiftUI
+import SwiftUIRefresh
 
 struct ItemListView: View {
 
     // MARK: - Property
 
     @Binding var items: [Item]
+    @Binding var isRefreshing: Bool
+
+    let onRefresh: () -> Void
 
     // MARK: - Body
 
@@ -21,6 +25,7 @@ struct ItemListView: View {
                 ItemListItem(item: item)
             }
         }.listStyle(PlainListStyle())
+        .pullToRefresh(isShowing: $isRefreshing, onRefresh: onRefresh)
     }
 }
 
@@ -61,8 +66,9 @@ struct ItemListItem: View {
 struct ItemListView_Previews: PreviewProvider {
 
     @State static var items: [Item] = ItemStubService.items
+    @State static var isLoading = false
 
     static var previews: some View {
-        ItemListView(items: $items)
+        ItemListView(items: $items, isRefreshing: $isLoading, onRefresh: { })
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/Profile/ProfileView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Profile/ProfileView.swift
@@ -29,12 +29,13 @@ struct ProfileView: View {
                     VStack(spacing: 0) {
                         UserInformationView(user: user)
 
-                        ItemListView(items: $viewModel.items)
+                        ItemListView(items: $viewModel.items, isRefreshing: $viewModel.isRefreshing, onRefresh: viewModel.fetchItems)
                     }
                 } else {
                     ProgressView()
                 }
-            }.navigationBarTitle("Profile", displayMode: .inline)
+            }
+            .navigationBarTitle("Profile", displayMode: .inline)
             .navigationBarItems(trailing: Button(action: { isPresented.toggle() }) {
                 Image(systemName: "gear")
                     .renderingMode(.template)

--- a/Qiita_SwiftUI/Presentation/Screen/Profile/ProfileViewModel.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Profile/ProfileViewModel.swift
@@ -14,6 +14,7 @@ final class ProfileViewModel: ObservableObject {
 
     @Published var user: User?
     @Published var items: [Item] = []
+    @Published var isRefreshing = false
 
     let authRepository: AuthRepository
     private let itemRepository: ItemRepository
@@ -50,6 +51,7 @@ final class ProfileViewModel: ObservableObject {
         itemRepository.getAuthenticatedUserItems(page: 1, perPage: 20)
             .receive(on: DispatchQueue.main)
             .sink(receiveCompletion: { completion in
+                self.isRefreshing = false
                 switch completion {
                 case .finished:
                     break

--- a/Qiita_SwiftUI/Presentation/Screen/SearchResult/SearchResultView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/SearchResult/SearchResultView.swift
@@ -22,7 +22,7 @@ struct SearchResultView: View {
     // MARK: - Body
 
     var body: some View {
-        ItemListView(items: $viewModel.items)
+        ItemListView(items: $viewModel.items, isRefreshing: $viewModel.isRefreshing, onRefresh: viewModel.fetchItems)
             .navigationTitle(navigationTitle)
     }
 

--- a/Qiita_SwiftUI/Presentation/Screen/SearchResult/SearchResultViewModel.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/SearchResult/SearchResultViewModel.swift
@@ -13,6 +13,7 @@ final class SearchResultViewModel: ObservableObject {
     // MARK: - Property
 
     @Published var items: [Item] = []
+    @Published var isRefreshing = false
     let searchType: SearchType
 
     private let itemRepository: ItemRepository
@@ -33,6 +34,7 @@ final class SearchResultViewModel: ObservableObject {
         itemRepository.getItems(with: searchType, page: 1)
             .receive(on: DispatchQueue.main)
             .sink(receiveCompletion: { completion in
+                self.isRefreshing = false
                 switch completion {
                 case .finished:
                     break

--- a/Qiita_SwiftUI/Presentation/Screen/Stock/StockView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Stock/StockView.swift
@@ -23,7 +23,7 @@ struct StockView: View {
 
     var body: some View {
         NavigationView {
-            ItemListView(items: $viewModel.items)
+            ItemListView(items: $viewModel.items, isRefreshing: $viewModel.isRefreshing, onRefresh: viewModel.fetchItems)
                 .navigationBarTitle("Stock", displayMode: .inline)
         }
     }

--- a/Qiita_SwiftUI/Presentation/Screen/Stock/StockViewModel.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Stock/StockViewModel.swift
@@ -13,6 +13,7 @@ final class StockViewModel: ObservableObject {
     // MARK: - Property
 
     @Published var items: [Item] = []
+    @Published var isRefreshing = false
 
     private let stockRepository: StockRepository
     private var cancellables = [AnyCancellable]()
@@ -31,6 +32,7 @@ final class StockViewModel: ObservableObject {
         stockRepository.getStocks(page: 1, perPage: 20)
             .receive(on: DispatchQueue.main)
             .sink(receiveCompletion: { completion in
+                self.isRefreshing = false
                 switch completion {
                 case .finished:
                     break


### PR DESCRIPTION
## 概要
- 一覧でPullToRefreshを実装する

## 実装
- `RefreshControl`がSwiftUIにデフォで存在しないので[SwiftUIRefresh](https://github.com/siteline/SwiftUIRefresh)を利用
- ItemListView側に`RefreshControl`を追加し、外から`isRefreshing`と`onRefresh`を受け取る形
    - `isRefreshing`は`Binding`なので、外から`isRefreshing = false`とすればクルクルが止まる

![Aug-27-2021 21-29-41](https://user-images.githubusercontent.com/44288050/131127910-1c57e267-8fdd-4d56-b2ef-dc790ecc8518.gif)
