### PR TITLE
記事詳細改善

### DIFF
--- a/Qiita_SwiftUI.xcodeproj/project.pbxproj
+++ b/Qiita_SwiftUI.xcodeproj/project.pbxproj
@@ -73,6 +73,8 @@
 		E2729DF9264F3ADC009473D0 /* StockStubService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DF8264F3ADC009473D0 /* StockStubService.swift */; };
 		E295D60B26D8AE4300246986 /* SwiftUIRefresh in Frameworks */ = {isa = PBXBuildFile; productRef = E295D60A26D8AE4300246986 /* SwiftUIRefresh */; };
 		E295D60D26D948AA00246986 /* WebViewRuleList.json in Resources */ = {isa = PBXBuildFile; fileRef = E295D60C26D948AA00246986 /* WebViewRuleList.json */; };
+		E295D60F26D9574800246986 /* ItemDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E295D60E26D9574800246986 /* ItemDetailViewModel.swift */; };
+		E295D61126D97A0800246986 /* LikeStubService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E295D61026D97A0800246986 /* LikeStubService.swift */; };
 		E2BB27692656654400148F45 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BB27682656654400148F45 /* ProfileView.swift */; };
 		E2BB276B2656657500148F45 /* ProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BB276A2656657500148F45 /* ProfileViewModel.swift */; };
 		E2BB276E2656904100148F45 /* SettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BB276D2656904100148F45 /* SettingView.swift */; };
@@ -170,6 +172,8 @@
 		E2729DF6264F3A0F009473D0 /* StockViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockViewModel.swift; sourceTree = "<group>"; };
 		E2729DF8264F3ADC009473D0 /* StockStubService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockStubService.swift; sourceTree = "<group>"; };
 		E295D60C26D948AA00246986 /* WebViewRuleList.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = WebViewRuleList.json; sourceTree = "<group>"; };
+		E295D60E26D9574800246986 /* ItemDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemDetailViewModel.swift; sourceTree = "<group>"; };
+		E295D61026D97A0800246986 /* LikeStubService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LikeStubService.swift; sourceTree = "<group>"; };
 		E2BB27682656654400148F45 /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
 		E2BB276A2656657500148F45 /* ProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewModel.swift; sourceTree = "<group>"; };
 		E2BB276D2656904100148F45 /* SettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingView.swift; sourceTree = "<group>"; };
@@ -466,6 +470,7 @@
 				E2729DF1264F24F8009473D0 /* ItemStubService.swift */,
 				E2729DF8264F3ADC009473D0 /* StockStubService.swift */,
 				E2BB27762656ACC000148F45 /* TagStubService.swift */,
+				E295D61026D97A0800246986 /* LikeStubService.swift */,
 			);
 			path = Stub;
 			sourceTree = "<group>";
@@ -501,6 +506,7 @@
 			isa = PBXGroup;
 			children = (
 				E2729DED264F15C4009473D0 /* ItemDetailView.swift */,
+				E295D60E26D9574800246986 /* ItemDetailViewModel.swift */,
 			);
 			path = ItemDetail;
 			sourceTree = "<group>";
@@ -713,6 +719,7 @@
 				E20DD32325FF40EE00735B0A /* ItemRepository.swift in Sources */,
 				E20DD34625FF44BA00735B0A /* API.swift in Sources */,
 				E2729DEB264F0D43009473D0 /* ImageView.swift in Sources */,
+				E295D60F26D9574800246986 /* ItemDetailViewModel.swift in Sources */,
 				E20DD31725FF403D00735B0A /* ItemTag.swift in Sources */,
 				E20DD3A825FF8FE400735B0A /* LaunchView.swift in Sources */,
 				E2BB27752656A90100148F45 /* SearchViewModel.swift in Sources */,
@@ -738,6 +745,7 @@
 				E20DD35925FF44D300735B0A /* Interceptor.swift in Sources */,
 				E20DD35E25FF44DC00735B0A /* AuthTokenInterceptor.swift in Sources */,
 				E20DD39325FF802900735B0A /* URL+.swift in Sources */,
+				E295D61126D97A0800246986 /* LikeStubService.swift in Sources */,
 				E20DD31325FF403D00735B0A /* VoidModel.swift in Sources */,
 				E20DD38825FF484000735B0A /* Logger.swift in Sources */,
 				E2BB27732656A8A600148F45 /* SearchView.swift in Sources */,

--- a/Qiita_SwiftUI.xcodeproj/project.pbxproj
+++ b/Qiita_SwiftUI.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		E2729DF7264F3A0F009473D0 /* StockViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DF6264F3A0F009473D0 /* StockViewModel.swift */; };
 		E2729DF9264F3ADC009473D0 /* StockStubService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DF8264F3ADC009473D0 /* StockStubService.swift */; };
 		E295D60B26D8AE4300246986 /* SwiftUIRefresh in Frameworks */ = {isa = PBXBuildFile; productRef = E295D60A26D8AE4300246986 /* SwiftUIRefresh */; };
+		E295D60D26D948AA00246986 /* WebViewRuleList.json in Resources */ = {isa = PBXBuildFile; fileRef = E295D60C26D948AA00246986 /* WebViewRuleList.json */; };
 		E2BB27692656654400148F45 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BB27682656654400148F45 /* ProfileView.swift */; };
 		E2BB276B2656657500148F45 /* ProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BB276A2656657500148F45 /* ProfileViewModel.swift */; };
 		E2BB276E2656904100148F45 /* SettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BB276D2656904100148F45 /* SettingView.swift */; };
@@ -168,6 +169,7 @@
 		E2729DF4264F39DC009473D0 /* StockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockView.swift; sourceTree = "<group>"; };
 		E2729DF6264F3A0F009473D0 /* StockViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockViewModel.swift; sourceTree = "<group>"; };
 		E2729DF8264F3ADC009473D0 /* StockStubService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockStubService.swift; sourceTree = "<group>"; };
+		E295D60C26D948AA00246986 /* WebViewRuleList.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = WebViewRuleList.json; sourceTree = "<group>"; };
 		E2BB27682656654400148F45 /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
 		E2BB276A2656657500148F45 /* ProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewModel.swift; sourceTree = "<group>"; };
 		E2BB276D2656904100148F45 /* SettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingView.swift; sourceTree = "<group>"; };
@@ -279,6 +281,7 @@
 			isa = PBXGroup;
 			children = (
 				E20DD2C625FF325900735B0A /* Assets.xcassets */,
+				E295D60C26D948AA00246986 /* WebViewRuleList.json */,
 			);
 			path = Resource;
 			sourceTree = "<group>";
@@ -667,6 +670,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E20DD2C725FF325900735B0A /* Assets.xcassets in Resources */,
+				E295D60D26D948AA00246986 /* WebViewRuleList.json in Resources */,
 				E20DD3D025FFA99100735B0A /* .env.sample in Resources */,
 				E20DD3CF25FFA99100735B0A /* .env in Resources */,
 			);

--- a/Qiita_SwiftUI/Presentation/Common/WebView.swift
+++ b/Qiita_SwiftUI/Presentation/Common/WebView.swift
@@ -10,10 +10,38 @@ import WebKit
 
 struct WebView: UIViewRepresentable {
 
+    // MARK: - Property
+
+    private let sharedConfig: WKWebViewConfiguration = {
+        let userContentController = WKUserContentController()
+        let fileName = "WebViewRuleList.json"
+
+        if let jsonFilePath = Bundle.main.path(forResource: fileName, ofType: nil),
+            let jsonFileContent = try? String(contentsOfFile: jsonFilePath, encoding: String.Encoding.utf8) {
+            WKContentRuleListStore.default().compileContentRuleList(forIdentifier: "qiita", encodedContentRuleList: jsonFileContent) { contentRuleList, error in
+                if let error = error {
+                    Logger.error(error)
+                    return
+                }
+                if let list = contentRuleList {
+                    userContentController.add(list)
+                }
+            }
+        }
+
+        let config = WKWebViewConfiguration()
+        config.userContentController = userContentController
+        config.websiteDataStore = .default()
+
+        return config
+    }()
+
     var url: URL
 
+    // MARK: - Public
+
     func makeUIView(context: Context) -> WKWebView {
-        return WKWebView()
+        return WKWebView(frame: .zero, configuration: sharedConfig)
     }
 
     func updateUIView(_ uiView: WKWebView, context: Context) {

--- a/Qiita_SwiftUI/Presentation/Screen/Home/HomeView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Home/HomeView.swift
@@ -13,17 +13,22 @@ struct HomeView: View {
 
     @ObservedObject private var viewModel: HomeViewModel
 
+    let likeRepository: LikeRepository
+    let stockRepository: StockRepository
+
     // MARK: - Initializer
 
-    init(itemRepository: ItemRepository) {
+    init(itemRepository: ItemRepository, likeRepository: LikeRepository, stockRepository: StockRepository) {
         self.viewModel = HomeViewModel(itemRepository: itemRepository)
+        self.likeRepository = likeRepository
+        self.stockRepository = stockRepository
     }
 
     // MARK: - Body
 
     var body: some View {
         NavigationView {
-            ItemListView(items: $viewModel.items, isRefreshing: $viewModel.isRefreshing, onRefresh: viewModel.fetchItems, onPaging: viewModel.fetchMoreItems)
+            ItemListView(items: $viewModel.items, isRefreshing: $viewModel.isRefreshing, likeRepository: likeRepository, stockRepository: stockRepository, onRefresh: viewModel.fetchItems, onPaging: viewModel.fetchMoreItems)
                 .navigationBarTitle("Home", displayMode: .inline)
         }
     }
@@ -31,6 +36,6 @@ struct HomeView: View {
 
 struct HomeView_Previews: PreviewProvider {
     static var previews: some View {
-        HomeView(itemRepository: ItemStubService())
+        HomeView(itemRepository: ItemStubService(), likeRepository: LikeStubService(), stockRepository: StockStubService())
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/Home/HomeViewModel.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Home/HomeViewModel.swift
@@ -18,7 +18,7 @@ final class HomeViewModel: ObservableObject {
     private var page = 1
     private var isPageLoading = false
 
-    private let itemRepository: ItemRepository
+    let itemRepository: ItemRepository
     private var cancellables = [AnyCancellable]()
 
     // MARK: - Initializer

--- a/Qiita_SwiftUI/Presentation/Screen/ItemDetail/ItemDetailView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/ItemDetail/ItemDetailView.swift
@@ -32,34 +32,48 @@ struct ItemDetailView: View {
                 Color.secondarySystemBackground
 
                 HStack(spacing: 36) {
-                    Button(systemImage: viewModel.isLiked ? .handThumbsupFill : .handThumbsup, action: {
-                        viewModel.isLiked ? viewModel.disLike() : viewModel.like()
-                    })
-                    .frame(width: 44, height: 44)
-                    .imageScale(.large)
-                    .border(Color(UIColor(named: "brand")!), width: 1, cornerRadius: 22)
-                    .foregroundColor(viewModel.isLiked ? Color.white : Color(UIColor(named: "brand")!))
-                    .background(viewModel.isLiked ? Color(UIColor(named: "brand")!) : Color.clear)
-                    .cornerRadius(22)
+                    if viewModel.isLiked {
+                        Button(systemImage: .handThumbsupFill, action: { viewModel.disLike() })
+                            .frame(width: 44, height: 44)
+                            .imageScale(.large)
+                            .border(Color("brand"), width: 1, cornerRadius: 22)
+                            .foregroundColor(Color.white)
+                            .background(Color("brand"))
+                            .cornerRadius(22)
+                    } else {
+                        Button(systemImage: .handThumbsup, action: { viewModel.like() })
+                            .frame(width: 44, height: 44)
+                            .imageScale(.large)
+                            .border(Color("brand"), width: 1, cornerRadius: 22)
+                            .foregroundColor(Color("brand"))
+                            .background(Color.clear)
+                            .cornerRadius(22)
+                    }
 
-                    Button(systemImage: viewModel.isStocked ? .folderFill : .folder, action: {
-                        viewModel.isStocked ? viewModel.unStock() : viewModel.stock()
-                    })
-                    .frame(width: 44, height: 44)
-                    .imageScale(.large)
-                    .border(Color(UIColor(named: "brand")!), width: 1, cornerRadius: 22)
-                    .foregroundColor(viewModel.isStocked ? Color.white : Color(UIColor(named: "brand")!))
-                    .background(viewModel.isStocked ? Color(UIColor(named: "brand")!) : Color.clear)
-                    .cornerRadius(22)
+                    if viewModel.isStocked {
+                        Button(systemImage: .folderFill, action: { viewModel.unStock() })
+                            .frame(width: 44, height: 44)
+                            .imageScale(.large)
+                            .border(Color("brand"), width: 1, cornerRadius: 22)
+                            .foregroundColor(Color.white)
+                            .background(Color("brand"))
+                            .cornerRadius(22)
+                    } else {
+                        Button(systemImage: .folder, action: { viewModel.stock() })
+                            .frame(width: 44, height: 44)
+                            .imageScale(.large)
+                            .border(Color("brand"), width: 1, cornerRadius: 22)
+                            .foregroundColor(Color("brand"))
+                            .background(Color.clear)
+                            .cornerRadius(22)
+                    }
 
-                    Button(systemImage: .squareAndArrowUp, action: {
-                        shareSheetPresented.toggle()
-                    })
-                    .frame(width: 44, height: 44)
-                    .imageScale(.large)
-                    .border(Color.systemGray, width: 1, cornerRadius: 22)
-                    .cornerRadius(22)
-                    .foregroundColor(.systemGray)
+                    Button(systemImage: .squareAndArrowUp, action: { shareSheetPresented.toggle() })
+                        .frame(width: 44, height: 44)
+                        .imageScale(.large)
+                        .border(Color.systemGray, width: 1, cornerRadius: 22)
+                        .cornerRadius(22)
+                        .foregroundColor(.systemGray)
                 }.sheet(isPresented: $shareSheetPresented, content: {
                     AppActivityView(activityItems: [viewModel.item.url])
                 })

--- a/Qiita_SwiftUI/Presentation/Screen/ItemDetail/ItemDetailView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/ItemDetail/ItemDetailView.swift
@@ -60,6 +60,9 @@ struct ItemDetailView: View {
                     .foregroundColor(.systemGray)
                 }
             }.frame(height: 60, alignment: .center)
+        }.onAppear {
+            viewModel.checkIsLiked()
+            viewModel.checkIsStocked()
         }
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/ItemDetail/ItemDetailView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/ItemDetail/ItemDetailView.swift
@@ -6,12 +6,14 @@
 //
 
 import SwiftUI
+import SwiftUIX
 
 struct ItemDetailView: View {
 
     // MARK: - Property
 
     @ObservedObject private var viewModel: ItemDetailViewModel
+    @State private var shareSheetPresented = false
 
     // MARK: - Initializer
 
@@ -51,14 +53,16 @@ struct ItemDetailView: View {
                     .cornerRadius(22)
 
                     Button(systemImage: .squareAndArrowUp, action: {
-
+                        shareSheetPresented.toggle()
                     })
                     .frame(width: 44, height: 44)
                     .imageScale(.large)
                     .border(Color.systemGray, width: 1, cornerRadius: 22)
                     .cornerRadius(22)
                     .foregroundColor(.systemGray)
-                }
+                }.sheet(isPresented: $shareSheetPresented, content: {
+                    AppActivityView(activityItems: [viewModel.item.url])
+                })
             }.frame(height: 60, alignment: .center)
         }.onAppear {
             viewModel.checkIsLiked()

--- a/Qiita_SwiftUI/Presentation/Screen/ItemDetail/ItemDetailView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/ItemDetail/ItemDetailView.swift
@@ -11,18 +11,61 @@ struct ItemDetailView: View {
 
     // MARK: - Property
 
-    var item: Item
+    @ObservedObject private var viewModel: ItemDetailViewModel
+
+    // MARK: - Initializer
+
+    init(item: Item, likeRepository: LikeRepository, stockRepository: StockRepository) {
+        viewModel = ItemDetailViewModel(item: item, likeRepository: likeRepository, stockRepository: stockRepository)
+    }
 
     // MARK: - Body
 
     var body: some View {
-        WebView(url: item.url)
-            .navigationTitle(item.title)
+        VStack(spacing: 0) {
+            WebView(url: viewModel.item.url)
+                .navigationTitle(viewModel.item.title)
+
+            ZStack {
+                Color.secondarySystemBackground
+
+                HStack(spacing: 36) {
+                    Button(systemImage: viewModel.isLiked ? .handThumbsupFill : .handThumbsup, action: {
+                        viewModel.isLiked ? viewModel.disLike() : viewModel.like()
+                    })
+                    .frame(width: 44, height: 44)
+                    .imageScale(.large)
+                    .border(Color(UIColor(named: "brand")!), width: 1, cornerRadius: 22)
+                    .foregroundColor(viewModel.isLiked ? Color.white : Color(UIColor(named: "brand")!))
+                    .background(viewModel.isLiked ? Color(UIColor(named: "brand")!) : Color.clear)
+                    .cornerRadius(22)
+
+                    Button(systemImage: viewModel.isStocked ? .folderFill : .folder, action: {
+                        viewModel.isStocked ? viewModel.unStock() : viewModel.stock()
+                    })
+                    .frame(width: 44, height: 44)
+                    .imageScale(.large)
+                    .border(Color(UIColor(named: "brand")!), width: 1, cornerRadius: 22)
+                    .foregroundColor(viewModel.isStocked ? Color.white : Color(UIColor(named: "brand")!))
+                    .background(viewModel.isStocked ? Color(UIColor(named: "brand")!) : Color.clear)
+                    .cornerRadius(22)
+
+                    Button(systemImage: .squareAndArrowUp, action: {
+
+                    })
+                    .frame(width: 44, height: 44)
+                    .imageScale(.large)
+                    .border(Color.systemGray, width: 1, cornerRadius: 22)
+                    .cornerRadius(22)
+                    .foregroundColor(.systemGray)
+                }
+            }.frame(height: 60, alignment: .center)
+        }
     }
 }
 
 struct ItemDetailView_Previews: PreviewProvider {
     static var previews: some View {
-        ItemDetailView(item: ItemStubService.items[0])
+        ItemDetailView(item: ItemStubService.items[0], likeRepository: LikeStubService(), stockRepository: StockStubService())
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/ItemDetail/ItemDetailViewModel.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/ItemDetail/ItemDetailViewModel.swift
@@ -27,9 +27,6 @@ final class ItemDetailViewModel: ObservableObject, Identifiable {
         self.item = item
         self.likeRepository = likeRepository
         self.stockRepository = stockRepository
-
-        checkIsLiked()
-        checkIsStocked()
     }
 
     // MARK: - Public
@@ -75,7 +72,7 @@ final class ItemDetailViewModel: ObservableObject, Identifiable {
                 case .finished:
                     break
                 case .failure(let error):
-                    self.isStocked = true
+                    self.isStocked = false
                     Logger.error(error)
                 }
             }, receiveValue: { _ in
@@ -98,9 +95,7 @@ final class ItemDetailViewModel: ObservableObject, Identifiable {
             }).store(in: &cancellables)
     }
 
-    // MARK: - Private
-
-    private func checkIsLiked() {
+    func checkIsLiked() {
         likeRepository.checkIsLiked(id: item.id)
             .receive(on: DispatchQueue.main)
             .sink(receiveCompletion: { completion in
@@ -116,7 +111,7 @@ final class ItemDetailViewModel: ObservableObject, Identifiable {
             }).store(in: &cancellables)
     }
 
-    private func checkIsStocked() {
+    func checkIsStocked() {
         stockRepository.checkIsStocked(id: item.id)
             .receive(on: DispatchQueue.main)
             .sink(receiveCompletion: { completion in

--- a/Qiita_SwiftUI/Presentation/Screen/ItemDetail/ItemDetailViewModel.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/ItemDetail/ItemDetailViewModel.swift
@@ -1,0 +1,134 @@
+//
+//  ItemDetailViewModel.swift
+//  Qiita_SwiftUI
+//
+//  Created by kntk on 2021/08/28.
+//
+
+import Foundation
+import SwiftUI
+import Combine
+
+final class ItemDetailViewModel: ObservableObject, Identifiable {
+
+    // MARK: - Property
+
+    private let likeRepository: LikeRepository
+    private let stockRepository: StockRepository
+    private var cancellables = [AnyCancellable]()
+
+    @Published var item: Item
+    @Published var isLiked: Bool = false
+    @Published var isStocked: Bool = false
+
+    // MARK: - Initializer
+
+    init(item: Item, likeRepository: LikeRepository, stockRepository: StockRepository) {
+        self.item = item
+        self.likeRepository = likeRepository
+        self.stockRepository = stockRepository
+
+        checkIsLiked()
+        checkIsStocked()
+    }
+
+    // MARK: - Public
+
+    func like() {
+        isLiked = true
+        likeRepository.like(id: item.id)
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { completion in
+                switch completion {
+                case .finished:
+                    break
+                case .failure(let error):
+                    self.isLiked = false
+                    Logger.error(error)
+                }
+            }, receiveValue: { _ in
+            }).store(in: &cancellables)
+    }
+
+    func disLike() {
+        isLiked = false
+        likeRepository.unlike(id: item.id)
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { completion in
+                switch completion {
+                case .finished:
+                    break
+                case .failure(let error):
+                    self.isLiked = true
+                    Logger.error(error)
+                }
+            }, receiveValue: { _ in
+            }).store(in: &cancellables)
+    }
+
+    func stock() {
+        isStocked = true
+        stockRepository.stock(id: item.id)
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { completion in
+                switch completion {
+                case .finished:
+                    break
+                case .failure(let error):
+                    self.isStocked = true
+                    Logger.error(error)
+                }
+            }, receiveValue: { _ in
+            }).store(in: &cancellables)
+    }
+
+    func unStock() {
+        isStocked = false
+        stockRepository.unstock(id: item.id)
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { completion in
+                switch completion {
+                case .finished:
+                    break
+                case .failure(let error):
+                    self.isStocked = true
+                    Logger.error(error)
+                }
+            }, receiveValue: { _ in
+            }).store(in: &cancellables)
+    }
+
+    // MARK: - Private
+
+    private func checkIsLiked() {
+        likeRepository.checkIsLiked(id: item.id)
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { completion in
+                switch completion {
+                case .finished:
+                    break
+                case .failure(let error):
+                    self.isLiked = false
+                    Logger.error(error)
+                }
+            }, receiveValue: { _ in
+                self.isLiked = true
+            }).store(in: &cancellables)
+    }
+
+    private func checkIsStocked() {
+        stockRepository.checkIsStocked(id: item.id)
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { completion in
+                switch completion {
+                case .finished:
+                    break
+                case .failure(let error):
+                    self.isStocked = false
+                    Logger.error(error)
+                }
+            }, receiveValue: { _ in
+                self.isStocked = true
+            }).store(in: &cancellables)
+    }
+}

--- a/Qiita_SwiftUI/Presentation/Screen/ItemList/ItemListView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/ItemList/ItemListView.swift
@@ -15,6 +15,9 @@ struct ItemListView: View {
     @Binding var items: [Item]
     @Binding var isRefreshing: Bool
 
+    let likeRepository: LikeRepository
+    let stockRepository: StockRepository
+
     let onRefresh: () -> Void
     let onPaging: () -> Void
 
@@ -23,7 +26,7 @@ struct ItemListView: View {
     var body: some View {
         List {
             ForEach(items) { item in
-                ItemListItem(item: item)
+                ItemListItem(item: item, likeRepository: likeRepository, stockRepository: stockRepository)
             }
 
             HStack {
@@ -43,8 +46,11 @@ struct ItemListItem: View {
 
     var item: Item
 
+    let likeRepository: LikeRepository
+    let stockRepository: StockRepository
+
     var body: some View {
-        NavigationLink(destination: ItemDetailView(item: item)) {
+        NavigationLink(destination: ItemDetailView(item: item, likeRepository: likeRepository, stockRepository: stockRepository)) {
             HStack {
                 ImageView(url: item.user.profileImageUrl)
                     .frame(width: 40, height: 40)
@@ -79,6 +85,6 @@ struct ItemListView_Previews: PreviewProvider {
     @State static var isLoading = false
 
     static var previews: some View {
-        ItemListView(items: $items, isRefreshing: $isLoading, onRefresh: { }, onPaging: { })
+        ItemListView(items: $items, isRefreshing: $isLoading, likeRepository: LikeStubService(), stockRepository: StockStubService(), onRefresh: { }, onPaging: { })
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/Launch/LaunchView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Launch/LaunchView.swift
@@ -13,6 +13,7 @@ struct LaunchView: View {
 
     @EnvironmentObject var authState: AuthState
 
+    let likeRepository: LikeRepository
     let authRepository: AuthRepository
     let itemRepository: ItemRepository
     let stockRepository: StockRepository
@@ -22,7 +23,7 @@ struct LaunchView: View {
 
     var body: some View {
         if authState.isSignedin {
-            MainView(authRepository: authRepository, itemRepository: itemRepository, stockRepository: stockRepository, tagRepository: tagRepository)
+            MainView(likeRepository: likeRepository, authRepository: authRepository, itemRepository: itemRepository, stockRepository: stockRepository, tagRepository: tagRepository)
         } else {
             LoginView(authRepository: authRepository)
         }
@@ -31,7 +32,7 @@ struct LaunchView: View {
 
 struct LaunchView_Previews: PreviewProvider {
     static var previews: some View {
-        LaunchView(authRepository: AuthStubService(), itemRepository: ItemStubService(), stockRepository: StockStubService(), tagRepository: TagStubService())
+        LaunchView(likeRepository: LikeStubService(), authRepository: AuthStubService(), itemRepository: ItemStubService(), stockRepository: StockStubService(), tagRepository: TagStubService())
             .environmentObject(AuthState(authRepository: AuthStubService()))
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/Main/MainView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Main/MainView.swift
@@ -11,6 +11,7 @@ struct MainView: View {
 
     // MARK: - Property
 
+    var likeRepository: LikeRepository
     var authRepository: AuthRepository
     var itemRepository: ItemRepository
     var stockRepository: StockRepository
@@ -20,22 +21,22 @@ struct MainView: View {
 
     var body: some View {
         TabView {
-            HomeView(itemRepository: itemRepository)
+            HomeView(itemRepository: itemRepository, likeRepository: likeRepository, stockRepository: stockRepository)
                 .tabItem {
                     Image(systemName: "house")
                     Text("Home")
                 }
-            SearchView(tagRepository: tagRepository, itemRepository: itemRepository)
+            SearchView(tagRepository: tagRepository, itemRepository: itemRepository, likeRepository: likeRepository, stockRepository: StockStubService())
                 .tabItem {
                     Image(systemName: "magnifyingglass")
                     Text("Search")
                 }
-            StockView(stockRepository: stockRepository)
+            StockView(stockRepository: stockRepository, itemRepository: itemRepository, likeRepository: likeRepository)
                 .tabItem {
                     Image(systemName: "folder")
                     Text("Stock")
                 }
-            ProfileView(authRepository: authRepository, itemRepository: itemRepository)
+            ProfileView(authRepository: authRepository, itemRepository: itemRepository, likeRepository: likeRepository, stockRepository: stockRepository)
                 .tabItem {
                     Image(systemName: "person")
                     Text("Profile")
@@ -46,6 +47,6 @@ struct MainView: View {
 
 struct MainView_Previews: PreviewProvider {
     static var previews: some View {
-        MainView(authRepository: AuthStubService(), itemRepository: ItemStubService(), stockRepository: StockStubService(), tagRepository: TagStubService())
+        MainView(likeRepository: LikeStubService(), authRepository: AuthStubService(), itemRepository: ItemStubService(), stockRepository: StockStubService(), tagRepository: TagStubService())
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/Profile/ProfileView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Profile/ProfileView.swift
@@ -14,10 +14,15 @@ struct ProfileView: View {
     @ObservedObject private var viewModel: ProfileViewModel
     @State private var isPresented = false
 
+    let likeRepository: LikeRepository
+    let stockRepository: StockRepository
+
     // MARK: - Initializer
 
-    init(authRepository: AuthRepository, itemRepository: ItemRepository) {
+    init(authRepository: AuthRepository, itemRepository: ItemRepository, likeRepository: LikeRepository, stockRepository: StockRepository) {
         self.viewModel = ProfileViewModel(authRepository: authRepository, itemRepository: itemRepository)
+        self.likeRepository = likeRepository
+        self.stockRepository = stockRepository
     }
 
     // MARK: - Body
@@ -29,7 +34,7 @@ struct ProfileView: View {
                     VStack(spacing: 0) {
                         UserInformationView(user: user)
 
-                        ItemListView(items: $viewModel.items, isRefreshing: $viewModel.isRefreshing, onRefresh: viewModel.fetchItems, onPaging: viewModel.fetchMoreItems)
+                        ItemListView(items: $viewModel.items, isRefreshing: $viewModel.isRefreshing, likeRepository: likeRepository, stockRepository: stockRepository, onRefresh: viewModel.fetchItems, onPaging: viewModel.fetchMoreItems)
                     }
                 } else {
                     ProgressView()
@@ -108,6 +113,6 @@ struct UserContributionView: View {
 
 struct ProfileView_Previews: PreviewProvider {
     static var previews: some View {
-        ProfileView(authRepository: AuthStubService(), itemRepository: ItemStubService())
+        ProfileView(authRepository: AuthStubService(), itemRepository: ItemStubService(), likeRepository: LikeStubService(), stockRepository: StockStubService())
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/Profile/ProfileViewModel.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Profile/ProfileViewModel.swift
@@ -20,7 +20,7 @@ final class ProfileViewModel: ObservableObject {
     private var isPageLoading = false
 
     let authRepository: AuthRepository
-    private let itemRepository: ItemRepository
+    let itemRepository: ItemRepository
     private var cancellables = [AnyCancellable]()
 
     // MARK: - Initializer

--- a/Qiita_SwiftUI/Presentation/Screen/Search/SearchView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Search/SearchView.swift
@@ -13,6 +13,8 @@ struct SearchView: View {
     // MARK: - Property
 
     private let itemRepository: ItemRepository
+    private let likeRepository: LikeRepository
+    private let stockRepository: StockRepository
     @ObservedObject private var viewModel: SearchViewModel
 
     @State var isEditing: Bool = false
@@ -22,9 +24,11 @@ struct SearchView: View {
 
     // MARK: - Initializer
 
-    init(tagRepository: TagRepository, itemRepository: ItemRepository) {
+    init(tagRepository: TagRepository, itemRepository: ItemRepository, likeRepository: LikeRepository, stockRepository: StockRepository) {
         self.viewModel = SearchViewModel(tagRepository: tagRepository)
         self.itemRepository = itemRepository
+        self.likeRepository = likeRepository
+        self.stockRepository = stockRepository
     }
 
     // MARK: - Body
@@ -32,9 +36,9 @@ struct SearchView: View {
     var body: some View {
         NavigationView {
             VStack {
-                TagListView(tags: viewModel.tags, itemRepository: itemRepository)
+                TagListView(tags: viewModel.tags, itemRepository: itemRepository, likeRepository: likeRepository, stockRepository: stockRepository)
 
-                NavigationLink(destination: SearchResultView(searchType: .word(searchText), itemRepository: itemRepository), isActive: $isPush) { EmptyView() }
+                NavigationLink(destination: SearchResultView(searchType: .word(searchText), itemRepository: itemRepository, likeRepository: likeRepository, stockRepository: stockRepository), isActive: $isPush) { EmptyView() }
                     .navigationBarTitle("Search", displayMode: .inline)
                     .navigationSearchBar {
                         SearchBar("キーワード検索", text: $searchText, isEditing: $isEditing, onCommit: { isPush.toggle() })
@@ -50,11 +54,13 @@ struct TagListView: View {
 
     let tags: [ItemTag]
     let itemRepository: ItemRepository
+    let likeRepository: LikeRepository
+    let stockRepository: StockRepository
 
     var body: some View {
         GeometryReader { geometry in
             CollectionView(tags) { tag in
-                NavigationLink(destination: SearchResultView(searchType: .tag(tag), itemRepository: itemRepository)) {
+                NavigationLink(destination: SearchResultView(searchType: .tag(tag), itemRepository: itemRepository, likeRepository: likeRepository, stockRepository: stockRepository)) {
                     ZStack {
                         ImageView(url: tag.iconUrl!)
 
@@ -76,6 +82,6 @@ struct TagListView: View {
 
 struct SearchView_Previews: PreviewProvider {
     static var previews: some View {
-        SearchView(tagRepository: TagStubService(), itemRepository: ItemStubService())
+        SearchView(tagRepository: TagStubService(), itemRepository: ItemStubService(), likeRepository: LikeStubService(), stockRepository: StockStubService())
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/SearchResult/SearchResultView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/SearchResult/SearchResultView.swift
@@ -12,17 +12,21 @@ struct SearchResultView: View {
     // MARK: - Property
 
     @ObservedObject private var viewModel: SearchResultViewModel
+    private let likeRepository: LikeRepository
+    private let stockRepository: StockRepository
 
     // MARK: - Initializer
 
-    init(searchType: SearchType, itemRepository: ItemRepository) {
+    init(searchType: SearchType, itemRepository: ItemRepository, likeRepository: LikeRepository, stockRepository: StockRepository) {
         viewModel = SearchResultViewModel(searchType: searchType, itemRepository: itemRepository)
+        self.likeRepository = likeRepository
+        self.stockRepository = stockRepository
     }
 
     // MARK: - Body
 
     var body: some View {
-        ItemListView(items: $viewModel.items, isRefreshing: $viewModel.isRefreshing, onRefresh: viewModel.fetchItems, onPaging: viewModel.fetchMoreItems)
+        ItemListView(items: $viewModel.items, isRefreshing: $viewModel.isRefreshing, likeRepository: likeRepository, stockRepository: stockRepository, onRefresh: viewModel.fetchItems, onPaging: viewModel.fetchMoreItems)
             .navigationTitle(navigationTitle)
     }
 
@@ -36,6 +40,6 @@ struct SearchResultView: View {
 
 struct SearchResultView_Previews: PreviewProvider {
     static var previews: some View {
-        SearchResultView(searchType: .word("iOS"), itemRepository: ItemStubService())
+        SearchResultView(searchType: .word("iOS"), itemRepository: ItemStubService(), likeRepository: LikeStubService(), stockRepository: StockStubService())
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/SearchResult/SearchResultViewModel.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/SearchResult/SearchResultViewModel.swift
@@ -19,7 +19,7 @@ final class SearchResultViewModel: ObservableObject {
     private var page = 1
     private var isPageLoading = false
 
-    private let itemRepository: ItemRepository
+    let itemRepository: ItemRepository
     private var cancellables = [AnyCancellable]()
 
     // MARK: - Initializer

--- a/Qiita_SwiftUI/Presentation/Screen/Stock/StockView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Stock/StockView.swift
@@ -12,18 +12,22 @@ struct StockView: View {
     // MARK: - Property
 
     @ObservedObject private var viewModel: StockViewModel
+    private let itemRepository: ItemRepository
+    private let likeRepository: LikeRepository
 
     // MARK: - Initializer
 
-    init(stockRepository: StockRepository) {
+    init(stockRepository: StockRepository, itemRepository: ItemRepository, likeRepository: LikeRepository) {
         self.viewModel = StockViewModel(stockRepository: stockRepository)
+        self.itemRepository = itemRepository
+        self.likeRepository = likeRepository
     }
 
     // MARK: - Body
 
     var body: some View {
         NavigationView {
-            ItemListView(items: $viewModel.items, isRefreshing: $viewModel.isRefreshing, onRefresh: viewModel.fetchItems, onPaging: viewModel.fetchMoreItems)
+            ItemListView(items: $viewModel.items, isRefreshing: $viewModel.isRefreshing, likeRepository: likeRepository, stockRepository: viewModel.stockRepository, onRefresh: viewModel.fetchItems, onPaging: viewModel.fetchMoreItems)
                 .navigationBarTitle("Stock", displayMode: .inline)
         }
     }
@@ -31,6 +35,6 @@ struct StockView: View {
 
 struct StockView_Previews: PreviewProvider {
     static var previews: some View {
-        StockView(stockRepository: StockStubService())
+        StockView(stockRepository: StockStubService(), itemRepository: ItemStubService(), likeRepository: LikeStubService())
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/Stock/StockViewModel.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Stock/StockViewModel.swift
@@ -18,7 +18,7 @@ final class StockViewModel: ObservableObject {
     private var page = 1
     private var isPageLoading = false
 
-    private let stockRepository: StockRepository
+    let stockRepository: StockRepository
     private var cancellables = [AnyCancellable]()
 
     // MARK: - Initializer

--- a/Qiita_SwiftUI/Qiita_SwiftUIApp.swift
+++ b/Qiita_SwiftUI/Qiita_SwiftUIApp.swift
@@ -12,7 +12,7 @@ struct Qiita_SwiftUIApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     var body: some Scene {
         WindowGroup {
-            LaunchView(authRepository: AppContainer.shared.authRepository, itemRepository: AppContainer.shared.itemRepository, stockRepository: AppContainer.shared.stockRepository, tagRepository: AppContainer.shared.tagRepository)
+            LaunchView(likeRepository: AppContainer.shared.likeRepository, authRepository: AppContainer.shared.authRepository, itemRepository: AppContainer.shared.itemRepository, stockRepository: AppContainer.shared.stockRepository, tagRepository: AppContainer.shared.tagRepository)
                 .environmentObject(AuthState(authRepository: AppContainer.shared.authRepository))
         }
     }

--- a/Qiita_SwiftUI/Resource/WebViewRuleList.json
+++ b/Qiita_SwiftUI/Resource/WebViewRuleList.json
@@ -1,0 +1,13 @@
+[
+    {
+        "trigger": {
+            "url-filter": ".*",
+            "if-domain": ["qiita.com"]
+        },
+        "action": {
+            "type": "css-display-none",
+            "selector": ".st-Header, .st-HeaderContainer, .it-ActionsMobile, .it-ActionsMobile-show, .apm-Content, .wb-CampaignLink, .css-109dbrr"
+        }
+
+    }
+]

--- a/Qiita_SwiftUI/Service/Stub/LikeStubService.swift
+++ b/Qiita_SwiftUI/Service/Stub/LikeStubService.swift
@@ -1,0 +1,24 @@
+//
+//  LikeStubService.swift
+//  Qiita_SwiftUI
+//
+//  Created by kntk on 2021/08/28.
+//
+
+import Foundation
+import Combine
+
+final class LikeStubService: LikeRepository {
+
+    func like(id: Item.ID) -> AnyPublisher<VoidModel, Error> {
+        return Future { $0(.success(VoidModel())) }.eraseToAnyPublisher()
+    }
+
+    func unlike(id: Item.ID) -> AnyPublisher<VoidModel, Error> {
+        return Future { $0(.success(VoidModel())) }.eraseToAnyPublisher()
+    }
+
+    func checkIsLiked(id: Item.ID) -> AnyPublisher<VoidModel, Error> {
+        return Future { $0(.success(VoidModel())) }.eraseToAnyPublisher()
+    }
+}


### PR DESCRIPTION
## 概要
- WebViewでアプリに不必要なcssを削除する
- 記事詳細でいいね/ストック/共有ができる様にする

## 実装
- WKWebViewConfigを利用してcssを削除
- 記事詳細のfooterにいいね/ストック/共有のボタンを配置
    - いいね/ストックの初期値設定はonAppear()で設定する
        - 最初initでやっていたが、Listの状態でinitが呼ばれてしまい、一覧でスクロールしているだけでいいね/ストック確認が発火してしまうため
- 共有は`SwiftUIX`の`AppActivity`を利用

<img width=300 src="https://user-images.githubusercontent.com/44288050/131206035-f33887d4-6485-4150-822a-d8b8078e078e.png">


## 備考
- Repositoryのバケツリレーがだるすぎるので治したい
    - バケツリレーにしているのは、PreviewであるViewにStubを注入した場合、それより下の階層のViewでも同じStubを利用したいため
    - 流石にだるいのでPreviewの時はStubで固定みたいな方法にするか？