### PR TITLE
画面で最初にAPIを叩いたりするタイミングを統一

### DIFF
--- a/Qiita_SwiftUI/Presentation/Screen/Home/HomeView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Home/HomeView.swift
@@ -13,6 +13,8 @@ struct HomeView: View {
 
     @ObservedObject private var viewModel: HomeViewModel
 
+    @State private var isInitialOnAppear = true
+
     let likeRepository: LikeRepository
     let stockRepository: StockRepository
 
@@ -30,6 +32,11 @@ struct HomeView: View {
         NavigationView {
             ItemListView(items: $viewModel.items, isRefreshing: $viewModel.isRefreshing, onItemStockChangedHandler: nil, likeRepository: likeRepository, stockRepository: stockRepository, onRefresh: viewModel.fetchItems, onPaging: viewModel.fetchMoreItems)
                 .navigationBarTitle("Home", displayMode: .inline)
+        }.onAppear {
+            if isInitialOnAppear {
+                viewModel.fetchItems()
+                isInitialOnAppear = false
+            }
         }
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/Home/HomeViewModel.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Home/HomeViewModel.swift
@@ -25,8 +25,6 @@ final class HomeViewModel: ObservableObject {
 
     init(itemRepository: ItemRepository) {
         self.itemRepository = itemRepository
-
-        fetchItems()
     }
 
     // MARK: - Public

--- a/Qiita_SwiftUI/Presentation/Screen/ItemDetail/ItemDetailView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/ItemDetail/ItemDetailView.swift
@@ -14,6 +14,7 @@ struct ItemDetailView: View {
 
     @ObservedObject private var viewModel: ItemDetailViewModel
     @State private var shareSheetPresented = false
+    @State private var isInitialOnAppear = true
 
     // MARK: - Initializer
 
@@ -79,8 +80,12 @@ struct ItemDetailView: View {
                 })
             }.frame(height: 60, alignment: .center)
         }.onAppear {
-            viewModel.checkIsLiked()
-            viewModel.checkIsStocked()
+            if isInitialOnAppear {
+                viewModel.checkIsLiked()
+                viewModel.checkIsStocked()
+                
+                isInitialOnAppear = false
+            }
         }
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/ItemList/ItemListItemViewModel.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/ItemList/ItemListItemViewModel.swift
@@ -30,8 +30,6 @@ final class ItemListItemViewModel: ObservableObject, Identifiable {
         self.onItemStockChangedHandler = onItemStockChangedHandler
         self.stockRepository = stockRepository
         self.likeRepository = likeRepository
-
-        checkIsStocked()
     }
 
     // MARK: - Public
@@ -70,9 +68,7 @@ final class ItemListItemViewModel: ObservableObject, Identifiable {
             }).store(in: &cancellables)
     }
 
-    // MARK: - Private
-
-    private func checkIsStocked() {
+    func checkIsStocked() {
         stockRepository.checkIsStocked(id: item.id)
             .receive(on: DispatchQueue.main)
             .sink(receiveCompletion: { completion in

--- a/Qiita_SwiftUI/Presentation/Screen/ItemList/ItemListView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/ItemList/ItemListView.swift
@@ -48,6 +48,8 @@ struct ItemListItem: View {
 
     @ObservedObject private var viewModel: ItemListItemViewModel
 
+    @State private var isInitialOnAppear = true
+
     // MARK: - Initializer
 
     init(item: Item, onItemStockChangedHandler: ((Item, Bool) -> Void)? = nil, stockRepository: StockRepository, likeRepository: LikeRepository) {
@@ -104,6 +106,13 @@ struct ItemListItem: View {
                         .cornerRadius(16)
                 }
             }.padding(.vertical, 8)
+        }.onAppear {
+            if isInitialOnAppear {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    self.viewModel.checkIsStocked()
+                }
+                isInitialOnAppear = false
+            }
         }
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/ItemList/ItemListView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/ItemList/ItemListView.swift
@@ -48,12 +48,14 @@ struct ItemListItem: View {
 
     @ObservedObject private var viewModel: ItemListItemViewModel
 
-    @State private var isInitialOnAppear = true
-
     // MARK: - Initializer
 
     init(item: Item, onItemStockChangedHandler: ((Item, Bool) -> Void)? = nil, stockRepository: StockRepository, likeRepository: LikeRepository) {
         self.viewModel = ItemListItemViewModel(item: item, onItemStockChangedHandler: onItemStockChangedHandler, stockRepository: stockRepository, likeRepository: likeRepository)
+
+        // FIXME: ここだけ例外的にonAppearではなくinitでやってる
+        // 1回だけのonAppearでやると、onAppearの後にListの更新がなぜか走り、checkしたステータスが初期化されてしまう
+        viewModel.checkIsStocked()
     }
 
     var body: some View {
@@ -106,13 +108,6 @@ struct ItemListItem: View {
                         .cornerRadius(16)
                 }
             }.padding(.vertical, 8)
-        }.onAppear {
-            if isInitialOnAppear {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                    self.viewModel.checkIsStocked()
-                }
-                isInitialOnAppear = false
-            }
         }
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/Profile/ProfileView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Profile/ProfileView.swift
@@ -13,6 +13,7 @@ struct ProfileView: View {
 
     @ObservedObject private var viewModel: ProfileViewModel
     @State private var isPresented = false
+    @State private var isInitialOnAppear = true
 
     let likeRepository: LikeRepository
     let stockRepository: StockRepository
@@ -46,7 +47,15 @@ struct ProfileView: View {
                     .renderingMode(.template)
                     .foregroundColor(Color("brand"))
             })
-        }.sheet(isPresented: $isPresented) {
+        }.onAppear {
+            if isInitialOnAppear {
+                viewModel.fetchUser()
+                viewModel.fetchItems()
+
+                isInitialOnAppear = false
+            }
+        }
+        .sheet(isPresented: $isPresented) {
             SettingView(authRepository: viewModel.authRepository, isPresenting: $isPresented)
         }
     }

--- a/Qiita_SwiftUI/Presentation/Screen/Profile/ProfileViewModel.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Profile/ProfileViewModel.swift
@@ -28,9 +28,6 @@ final class ProfileViewModel: ObservableObject {
     init(authRepository: AuthRepository, itemRepository: ItemRepository) {
         self.authRepository = authRepository
         self.itemRepository = itemRepository
-
-        fetchUser()
-        fetchItems()
     }
 
     // MARK: - Public

--- a/Qiita_SwiftUI/Presentation/Screen/Search/SearchView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Search/SearchView.swift
@@ -20,6 +20,7 @@ struct SearchView: View {
     @State var isEditing: Bool = false
     @State private var searchText: String = ""
 
+    @State private var isInitialOnAppear = true
     @State private var isPush: Bool = false
 
     // MARK: - Initializer
@@ -45,6 +46,11 @@ struct SearchView: View {
                             .showsCancelButton(isEditing)
 
                 }
+            }
+        }.onAppear {
+            if isInitialOnAppear {
+                viewModel.fetchTags()
+                isInitialOnAppear = false
             }
         }
     }

--- a/Qiita_SwiftUI/Presentation/Screen/Search/SearchViewModel.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Search/SearchViewModel.swift
@@ -21,8 +21,6 @@ final class SearchViewModel: ObservableObject {
 
     init(tagRepository: TagRepository) {
         self.tagRepository = tagRepository
-
-        fetchTags()
     }
 
     // MARK: - Public

--- a/Qiita_SwiftUI/Presentation/Screen/SearchResult/SearchResultView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/SearchResult/SearchResultView.swift
@@ -15,6 +15,8 @@ struct SearchResultView: View {
     private let likeRepository: LikeRepository
     private let stockRepository: StockRepository
 
+    @State private var isInitialOnAppear = true
+
     // MARK: - Initializer
 
     init(searchType: SearchType, itemRepository: ItemRepository, likeRepository: LikeRepository, stockRepository: StockRepository) {
@@ -28,6 +30,12 @@ struct SearchResultView: View {
     var body: some View {
         ItemListView(items: $viewModel.items, isRefreshing: $viewModel.isRefreshing, onItemStockChangedHandler: nil, likeRepository: likeRepository, stockRepository: stockRepository, onRefresh: viewModel.fetchItems, onPaging: viewModel.fetchMoreItems)
             .navigationTitle(navigationTitle)
+            .onAppear {
+                if isInitialOnAppear {
+                    viewModel.fetchItems()
+                    isInitialOnAppear = false
+                }
+            }
     }
 
     var navigationTitle: String {

--- a/Qiita_SwiftUI/Presentation/Screen/SearchResult/SearchResultViewModel.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/SearchResult/SearchResultViewModel.swift
@@ -27,8 +27,6 @@ final class SearchResultViewModel: ObservableObject {
     init(searchType: SearchType, itemRepository: ItemRepository) {
         self.searchType = searchType
         self.itemRepository = itemRepository
-
-        fetchItems()
     }
 
     // MARK: - Public

--- a/Qiita_SwiftUI/Presentation/Screen/Stock/StockView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Stock/StockView.swift
@@ -15,6 +15,8 @@ struct StockView: View {
     private let itemRepository: ItemRepository
     private let likeRepository: LikeRepository
 
+    @State private var isInitialOnAppear = true
+
     // MARK: - Initializer
 
     init(stockRepository: StockRepository, itemRepository: ItemRepository, likeRepository: LikeRepository) {
@@ -29,6 +31,11 @@ struct StockView: View {
         NavigationView {
             ItemListView(items: $viewModel.items, isRefreshing: $viewModel.isRefreshing, onItemStockChangedHandler: viewModel.onItemStockChangedHandler, likeRepository: likeRepository, stockRepository: viewModel.stockRepository, onRefresh: viewModel.fetchItems, onPaging: viewModel.fetchMoreItems)
                 .navigationBarTitle("Stock", displayMode: .inline)
+        }.onAppear {
+            if isInitialOnAppear {
+                viewModel.fetchItems()
+                isInitialOnAppear = false
+            }
         }
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/Stock/StockViewModel.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Stock/StockViewModel.swift
@@ -32,8 +32,6 @@ final class StockViewModel: ObservableObject {
             guard let self = self, let targetIndex = self.items.firstIndex(where: { $0.id == item.id }) else { return }
             self.items.remove(at: targetIndex)
         }
-
-        fetchItems()
     }
 
     // MARK: - Public


### PR DESCRIPTION
## 概要
- APIを叩いたりするのを`init`や`onAppear`でバラバラにAPIを叩いていたが、良いタイミングに統一する

## 実装

### `onAppear`, `init`の仕様
- `onAppear:` viewWillAppearと同じ、コンポーネントが見えるたびに呼ぶ
- `init`: 初期化された時に呼ばれるのでviewDidAppearかと思いきや
`NavigationLink(HogeView())`とやると`HogeView`の`init`が走っているので、画面遷移前に呼ばれることがある

### 結論
- 各画面で1回目を表すフラグを持っておき、`onAppear`の中で`if flag`するで`viewDidLoad`的な役割にする
```swift
@State private var isInitialOnAppear = true

.onAppear {
    if isInitialOnAppear {
        // viewDidLoad
        isInitialOnAppear = false
    }
    // viewWillAppear
}
```
- 一覧セルのストック状態を確認する`ItemListItem.checkIsStock`だけはinitで
    - 初回のonAppearの後にListの更新がなぜか走り、checkしたステータスが初期化されてしまう