### PR TITLE
キーワード検索を実装する

### DIFF
--- a/Qiita_SwiftUI/Presentation/Screen/Main/MainView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Main/MainView.swift
@@ -26,7 +26,7 @@ struct MainView: View {
                     Image(systemName: "house")
                     Text("Home")
                 }
-            SearchView(tagRepository: tagRepository, itemRepository: itemRepository, likeRepository: likeRepository, stockRepository: StockStubService())
+            SearchView(tagRepository: tagRepository, itemRepository: itemRepository, likeRepository: likeRepository, stockRepository: StockService())
                 .tabItem {
                     Image(systemName: "magnifyingglass")
                     Text("Search")

--- a/Qiita_SwiftUI/Presentation/Screen/Search/SearchView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Search/SearchView.swift
@@ -37,6 +37,8 @@ struct SearchView: View {
     var body: some View {
         NavigationView {
             GeometryReader { geometry in
+                NavigationLink(destination: SearchResultView(searchType: .word(searchText), itemRepository: itemRepository, likeRepository: likeRepository, stockRepository: stockRepository), isActive: $isPush) { EmptyView() }
+
                 // ヘッダーも含めてスクロールさせたいが
                 // ListやCollectionViewのヘッダーが存在しないので
                 // ScrollViewで囲い、中のCollectionViewの高さを固定長(スクロールなし)にして実装する
@@ -62,20 +64,21 @@ struct SearchView: View {
                     TagListView(tags: viewModel.tags, itemRepository: itemRepository, likeRepository: likeRepository, stockRepository: stockRepository)
                         // scrollDisableが反応しないのでcontent以上の高さにしてスクロールできなくする
                         .height((geometry.size.width / 3) * 10 + 5)
-
-                    NavigationLink(destination: SearchResultView(searchType: .word(searchText), itemRepository: itemRepository, likeRepository: likeRepository, stockRepository: stockRepository), isActive: $isPush) { EmptyView() }
-                        .navigationBarTitle("Search", displayMode: .inline)
-                        .navigationSearchBar {
-                            SearchBar("キーワード検索", text: $searchText, isEditing: $isEditing, onCommit: { isPush.toggle() })
-                                .showsCancelButton(isEditing)
-
-                        }
                 }
-            }.onAppear {
+            }
+            .navigationBarTitle("Search", displayMode: .inline)
+            .navigationSearchBar {
+                SearchBar("キーワード検索", text: $searchText, isEditing: $isEditing, onCommit: { isPush.toggle() })
+                    .showsCancelButton(isEditing)
+
+            }
+            .onAppear {
                 if isInitialOnAppear {
                     viewModel.fetchTags()
                     isInitialOnAppear = false
                 }
+
+                searchText = ""
             }
         }
     }

--- a/Qiita_SwiftUI/Presentation/Screen/Search/SearchView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Search/SearchView.swift
@@ -36,33 +36,43 @@ struct SearchView: View {
 
     var body: some View {
         NavigationView {
-            VStack(alignment: .leading) {
+            GeometryReader { geometry in
+                ScrollView {
 
-                Text("キーワード検索")
-                    .padding(.leading, 4)
+                    HStack {
+                        Text("キーワード検索")
+                            .padding(.leading, 4)
+                        Spacer()
+                    }
 
-                KeywordListView(keywords: ["Firebase", "ARKit", "GitHub", "iPadOS", "ライブラリ", "iOS15", "SwiftUI", "MacOS"]) { keyword in
-                    searchText = keyword
-                    isPush = true
-                }.height(100)
+                    KeywordListView(keywords: ["Firebase", "ARKit", "GitHub", "iPadOS", "ライブラリ", "iOS15", "SwiftUI", "MacOS"]) { keyword in
+                        searchText = keyword
+                        isPush = true
+                    }.height(100)
 
-                Text("タグ検索")
-                    .padding(.leading, 4)
+                    HStack {
+                        Text("タグ検索")
+                            .padding(.leading, 4)
+                        Spacer()
+                    }
 
-                TagListView(tags: viewModel.tags, itemRepository: itemRepository, likeRepository: likeRepository, stockRepository: stockRepository)
+                    TagListView(tags: viewModel.tags, itemRepository: itemRepository, likeRepository: likeRepository, stockRepository: stockRepository)
+                        // scrollDisableが反応しないのでcontent以上の高さにしてスクロールできなくする
+                        .height((geometry.size.width / 3) * 10 + 5)
 
-                NavigationLink(destination: SearchResultView(searchType: .word(searchText), itemRepository: itemRepository, likeRepository: likeRepository, stockRepository: stockRepository), isActive: $isPush) { EmptyView() }
-                    .navigationBarTitle("Search", displayMode: .inline)
-                    .navigationSearchBar {
-                        SearchBar("キーワード検索", text: $searchText, isEditing: $isEditing, onCommit: { isPush.toggle() })
-                            .showsCancelButton(isEditing)
+                    NavigationLink(destination: SearchResultView(searchType: .word(searchText), itemRepository: itemRepository, likeRepository: likeRepository, stockRepository: stockRepository), isActive: $isPush) { EmptyView() }
+                        .navigationBarTitle("Search", displayMode: .inline)
+                        .navigationSearchBar {
+                            SearchBar("キーワード検索", text: $searchText, isEditing: $isEditing, onCommit: { isPush.toggle() })
+                                .showsCancelButton(isEditing)
 
+                        }
                 }
-            }
-        }.onAppear {
-            if isInitialOnAppear {
-                viewModel.fetchTags()
-                isInitialOnAppear = false
+            }.onAppear {
+                if isInitialOnAppear {
+                    viewModel.fetchTags()
+                    isInitialOnAppear = false
+                }
             }
         }
     }
@@ -120,7 +130,8 @@ struct TagListView: View {
                     .frame(width: max(0.0, (geometry.size.width - 2) / 3), height: max(0.0, (geometry.size.width - 2) / 3))
                     // なんか1.0だとレイアウトが崩れる(小数演算の問題か)
                 }
-            }.collectionViewLayout(FlowCollectionViewLayout(minimumLineSpacing: 1, minimumInteritemSpacing: 0.99))
+            }
+            .collectionViewLayout(FlowCollectionViewLayout(minimumLineSpacing: 1, minimumInteritemSpacing: 0.99))
         }
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/Search/SearchView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Search/SearchView.swift
@@ -36,7 +36,19 @@ struct SearchView: View {
 
     var body: some View {
         NavigationView {
-            VStack {
+            VStack(alignment: .leading) {
+
+                Text("キーワード検索")
+                    .padding(.leading, 4)
+
+                KeywordListView(keywords: ["Firebase", "ARKit", "GitHub", "iPadOS", "ライブラリ", "iOS15", "SwiftUI", "MacOS"]) { keyword in
+                    searchText = keyword
+                    isPush = true
+                }.height(100)
+
+                Text("タグ検索")
+                    .padding(.leading, 4)
+
                 TagListView(tags: viewModel.tags, itemRepository: itemRepository, likeRepository: likeRepository, stockRepository: stockRepository)
 
                 NavigationLink(destination: SearchResultView(searchType: .word(searchText), itemRepository: itemRepository, likeRepository: likeRepository, stockRepository: stockRepository), isActive: $isPush) { EmptyView() }
@@ -53,6 +65,33 @@ struct SearchView: View {
                 isInitialOnAppear = false
             }
         }
+    }
+}
+
+struct KeywordListView: View {
+
+    // MARK: - Property
+
+    let keywords: [String]
+    let onKeywordTapHandler: ((String) -> Void)?
+
+    // MARK: - Body
+
+    var body: some View {
+        CollectionView(keywords, id: \.hashValue) { keyword in
+            // boderの前と後で.paddingの効果が変わる
+            // 前はinner padding, 後はouter padding(margin)
+            Button(keyword) { onKeywordTapHandler?(keyword) }
+                .padding(.horizontal, 2)
+                .padding(.vertical, 2)
+                .border(Color("brand"), width: 1, cornerRadius: 22)
+                .padding(.horizontal, 2)
+                .padding(.vertical, 3)
+                .foregroundColor(Color("brand"))
+                .background(Color.clear)
+                .cornerRadius(22)
+        }.collectionViewLayout(FlowCollectionViewLayout())
+        .padding(.horizontal, 2)
     }
 }
 

--- a/Qiita_SwiftUI/Presentation/Screen/Search/SearchView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Search/SearchView.swift
@@ -37,6 +37,9 @@ struct SearchView: View {
     var body: some View {
         NavigationView {
             GeometryReader { geometry in
+                // ヘッダーも含めてスクロールさせたいが
+                // ListやCollectionViewのヘッダーが存在しないので
+                // ScrollViewで囲い、中のCollectionViewの高さを固定長(スクロールなし)にして実装する
                 ScrollView {
 
                     HStack {


### PR DESCRIPTION
## 概要
- 検索画面でキーワード検索を追加

## 実装
- SwiftUIXの`CollectionView`を使用
    - 行ごとにItemの幅を変えれるのは素晴らしい
- ヘッダーを含めてスクロールできるように
    - `CollectionView`にHeaderが存在しないので、`CollectionView`をスクロールできなくして`ScrollView`で囲うことで対処
    - `CollectionView`の`scrollDisable`が機能していなかったのでcontent以上の高さを指定することでスクロールなしに
- 検索後画面のstockがおかしい問題
    - StockStubService入れてた()

<img width=300 src="https://user-images.githubusercontent.com/44288050/132833046-40438055-fdd5-43d0-a7ab-5eab708058e9.png">
