### PR TITLE
DIを修正する

### DIFF
--- a/Qiita_SwiftUI.xcodeproj/project.pbxproj
+++ b/Qiita_SwiftUI.xcodeproj/project.pbxproj
@@ -63,6 +63,8 @@
 		E25E9A7026E7471B0090A0E3 /* ItemListItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25E9A6F26E7471B0090A0E3 /* ItemListItemViewModel.swift */; };
 		E25E9A8A26EE62680090A0E3 /* TagInformationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25E9A8926EE62680090A0E3 /* TagInformationViewModel.swift */; };
 		E25E9A8D26EE74350090A0E3 /* TagInformationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25E9A8C26EE74350090A0E3 /* TagInformationView.swift */; };
+		E25E9A9326EE9F0B0090A0E3 /* RepositoryContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25E9A9226EE9F0B0090A0E3 /* RepositoryContainer.swift */; };
+		E25E9A9526EE9F320090A0E3 /* UserStubService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25E9A9426EE9F320090A0E3 /* UserStubService.swift */; };
 		E2729DE1264EC601009473D0 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DE0264EC601009473D0 /* HomeView.swift */; };
 		E2729DE3264ECA96009473D0 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DE2264ECA96009473D0 /* HomeViewModel.swift */; };
 		E2729DE6264ECDA7009473D0 /* ItemListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DE5264ECDA7009473D0 /* ItemListView.swift */; };
@@ -167,6 +169,8 @@
 		E25E9A6F26E7471B0090A0E3 /* ItemListItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemListItemViewModel.swift; sourceTree = "<group>"; };
 		E25E9A8926EE62680090A0E3 /* TagInformationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagInformationViewModel.swift; sourceTree = "<group>"; };
 		E25E9A8C26EE74350090A0E3 /* TagInformationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagInformationView.swift; sourceTree = "<group>"; };
+		E25E9A9226EE9F0B0090A0E3 /* RepositoryContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryContainer.swift; sourceTree = "<group>"; };
+		E25E9A9426EE9F320090A0E3 /* UserStubService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserStubService.swift; sourceTree = "<group>"; };
 		E2729DE0264EC601009473D0 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		E2729DE2264ECA96009473D0 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		E2729DE5264ECDA7009473D0 /* ItemListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemListView.swift; sourceTree = "<group>"; };
@@ -465,6 +469,7 @@
 			isa = PBXGroup;
 			children = (
 				E20DD3A225FF8F5700735B0A /* AuthState.swift */,
+				E25E9A9226EE9F0B0090A0E3 /* RepositoryContainer.swift */,
 			);
 			path = Environment;
 			sourceTree = "<group>";
@@ -477,6 +482,7 @@
 				E2729DF8264F3ADC009473D0 /* StockStubService.swift */,
 				E2BB27762656ACC000148F45 /* TagStubService.swift */,
 				E295D61026D97A0800246986 /* LikeStubService.swift */,
+				E25E9A9426EE9F320090A0E3 /* UserStubService.swift */,
 			);
 			path = Stub;
 			sourceTree = "<group>";
@@ -723,6 +729,7 @@
 				E20DD33425FF40FC00735B0A /* ItemService.swift in Sources */,
 				E2BB277F2656C2CB00148F45 /* SearchResultView.swift in Sources */,
 				E20DD34525FF44BA00735B0A /* BaseTarget.swift in Sources */,
+				E25E9A9326EE9F0B0090A0E3 /* RepositoryContainer.swift in Sources */,
 				E20DD30925FF3EAA00735B0A /* AppEnvironment.swift in Sources */,
 				E20DD35125FF44C600735B0A /* UserTarget.swift in Sources */,
 				E20DD35325FF44C600735B0A /* AuthTarget.swift in Sources */,
@@ -750,6 +757,7 @@
 				E2729DEE264F15C4009473D0 /* ItemDetailView.swift in Sources */,
 				E2729DF5264F39DC009473D0 /* StockView.swift in Sources */,
 				E2729DE6264ECDA7009473D0 /* ItemListView.swift in Sources */,
+				E25E9A9526EE9F320090A0E3 /* UserStubService.swift in Sources */,
 				E2729DF9264F3ADC009473D0 /* StockStubService.swift in Sources */,
 				E20DD3C625FF9E3A00735B0A /* SafariView.swift in Sources */,
 				E20DD30825FF3EAA00735B0A /* AppError.swift in Sources */,

--- a/Qiita_SwiftUI/Application/AppContainer.swift
+++ b/Qiita_SwiftUI/Application/AppContainer.swift
@@ -16,13 +16,7 @@ final class AppContainer {
 
     // MARK: - Property
 
-    let itemRepository: ItemRepository
-    let tagRepository: TagRepository
-    let stockRepository: StockRepository
-    let userRepository: UserRepository
-    let likeRepository: LikeRepository
-    let authRepository: AuthRepository
-
+    let repositoryContainer: RepositoryContainer
     let apiProvider: MoyaProvider<MultiTarget>
 
     // MARK: - Private
@@ -30,13 +24,8 @@ final class AppContainer {
     private init() {
         switch AppEnvironment.shared.buildConfig {
         case .debug, .release:
-            itemRepository = ItemService()
-            tagRepository = TagService()
-            stockRepository = StockService()
-            userRepository = UserService()
-            likeRepository = LikeService()
-            authRepository = AuthService()
-            
+
+            repositoryContainer = RepositoryContainerFactory.createServices()
             apiProvider = APIProviderFactory.createDefault()
         }
     }

--- a/Qiita_SwiftUI/Presentation/Environment/RepositoryContainer.swift
+++ b/Qiita_SwiftUI/Presentation/Environment/RepositoryContainer.swift
@@ -1,0 +1,42 @@
+//
+//  RepositoryContainer.swift
+//  Qiita_SwiftUI
+//
+//  Created by kntk on 2021/09/13.
+//
+
+import Foundation
+
+final class RepositoryContainer: ObservableObject {
+
+    // MARK: - Property
+
+    let itemRepository: ItemRepository
+    let tagRepository: TagRepository
+    let stockRepository: StockRepository
+    let userRepository: UserRepository
+    let likeRepository: LikeRepository
+    let authRepository: AuthRepository
+
+    // MARK: - Initializer
+    init(itemRepository: ItemRepository, tagRepository: TagRepository, stockRepository: StockRepository, userRepository: UserRepository, likeRepository: LikeRepository, authRepository: AuthRepository) {
+        self.itemRepository = itemRepository
+        self.tagRepository = tagRepository
+        self.stockRepository = stockRepository
+        self.userRepository = userRepository
+        self.likeRepository = likeRepository
+        self.authRepository = authRepository
+    }
+}
+
+final class RepositoryContainerFactory {
+
+    static func createServices() -> RepositoryContainer {
+        return RepositoryContainer(itemRepository: ItemService(), tagRepository: TagService(), stockRepository: StockService(), userRepository: UserService(), likeRepository: LikeService(), authRepository: AuthService())
+    }
+
+    static func createStubs() -> RepositoryContainer {
+        return RepositoryContainer(itemRepository: ItemStubService(), tagRepository: TagStubService(), stockRepository: StockStubService(), userRepository: UserStubService(), likeRepository: LikeStubService(), authRepository: AuthStubService())
+    }
+}
+

--- a/Qiita_SwiftUI/Presentation/Screen/Home/HomeView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Home/HomeView.swift
@@ -11,26 +11,24 @@ struct HomeView: View {
 
     // MARK: - Property
 
+    @EnvironmentObject var repositoryContainer: RepositoryContainer
+
     @ObservedObject private var viewModel: HomeViewModel
 
     @State private var isInitialOnAppear = true
 
-    let likeRepository: LikeRepository
-    let stockRepository: StockRepository
 
     // MARK: - Initializer
 
-    init(itemRepository: ItemRepository, likeRepository: LikeRepository, stockRepository: StockRepository) {
-        self.viewModel = HomeViewModel(itemRepository: itemRepository)
-        self.likeRepository = likeRepository
-        self.stockRepository = stockRepository
+    init(viewModel: HomeViewModel) {
+        self.viewModel = viewModel
     }
 
     // MARK: - Body
 
     var body: some View {
         NavigationView {
-            ItemListView(items: $viewModel.items, isRefreshing: $viewModel.isRefreshing, onItemStockChangedHandler: nil, likeRepository: likeRepository, stockRepository: stockRepository, onRefresh: viewModel.fetchItems, onPaging: viewModel.fetchMoreItems)
+            ItemListView(items: $viewModel.items, isRefreshing: $viewModel.isRefreshing, onItemStockChangedHandler: nil, onRefresh: viewModel.fetchItems, onPaging: viewModel.fetchMoreItems)
                 .navigationBarTitle("Home", displayMode: .inline)
         }.onAppear {
             if isInitialOnAppear {
@@ -43,6 +41,6 @@ struct HomeView: View {
 
 struct HomeView_Previews: PreviewProvider {
     static var previews: some View {
-        HomeView(itemRepository: ItemStubService(), likeRepository: LikeStubService(), stockRepository: StockStubService())
+        HomeView(viewModel: HomeViewModel(itemRepository: ItemStubService()))
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/Home/HomeView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Home/HomeView.swift
@@ -42,5 +42,6 @@ struct HomeView: View {
 struct HomeView_Previews: PreviewProvider {
     static var previews: some View {
         HomeView(viewModel: HomeViewModel(itemRepository: ItemStubService()))
+            .environmentObject(RepositoryContainerFactory.createStubs())
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/ItemDetail/ItemDetailView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/ItemDetail/ItemDetailView.swift
@@ -18,8 +18,8 @@ struct ItemDetailView: View {
 
     // MARK: - Initializer
 
-    init(item: Item, likeRepository: LikeRepository, stockRepository: StockRepository) {
-        viewModel = ItemDetailViewModel(item: item, likeRepository: likeRepository, stockRepository: stockRepository)
+    init(viewModel: ItemDetailViewModel) {
+        self.viewModel = viewModel
     }
 
     // MARK: - Body
@@ -92,6 +92,6 @@ struct ItemDetailView: View {
 
 struct ItemDetailView_Previews: PreviewProvider {
     static var previews: some View {
-        ItemDetailView(item: ItemStubService.items[0], likeRepository: LikeStubService(), stockRepository: StockStubService())
+        ItemDetailView(viewModel: ItemDetailViewModel(item: ItemStubService.items[0], likeRepository: LikeStubService(), stockRepository: StockStubService()))
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/ItemList/ItemListView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/ItemList/ItemListView.swift
@@ -72,6 +72,7 @@ struct ItemListView<HeaderView: View>: View {
 
 struct ItemListItem: View {
 
+    @EnvironmentObject var repositoryContainer: RepositoryContainer
     @ObservedObject private var viewModel: ItemListItemViewModel
 
     // MARK: - Initializer
@@ -85,7 +86,7 @@ struct ItemListItem: View {
     }
 
     var body: some View {
-        NavigationLink(destination: ItemDetailView(viewModel: ItemDetailViewModel(item: viewModel.item, likeRepository: viewModel.likeRepository, stockRepository: viewModel.stockRepository))) {
+        NavigationLink(destination: ItemDetailView(viewModel: ItemDetailViewModel(item: viewModel.item, likeRepository: repositoryContainer.likeRepository, stockRepository: repositoryContainer.stockRepository))) {
             HStack {
                 ImageView(url: viewModel.item.user.profileImageUrl)
                     .frame(width: 40, height: 40)

--- a/Qiita_SwiftUI/Presentation/Screen/ItemList/ItemListView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/ItemList/ItemListView.swift
@@ -12,37 +12,32 @@ struct ItemListView<HeaderView: View>: View {
 
     // MARK: - Property
 
+    @EnvironmentObject var repositoryContainer: RepositoryContainer
+
     @Binding private var items: [Item]
     @Binding private var isRefreshing: Bool
 
     private let onItemStockChangedHandler: ((Item, Bool) -> Void)?
-
-    private let likeRepository: LikeRepository
-    private let stockRepository: StockRepository
 
     private let onRefresh: () -> Void
     private let onPaging: () -> Void
 
     private var headerView: HeaderView
 
-    init(items: Binding<[Item]>, isRefreshing: Binding<Bool>, onItemStockChangedHandler: ((Item, Bool) -> Void)? = nil, likeRepository: LikeRepository, stockRepository: StockRepository, onRefresh: @escaping () -> Void, onPaging: @escaping () -> Void, @ViewBuilder header: () -> HeaderView) {
+    init(items: Binding<[Item]>, isRefreshing: Binding<Bool>, onItemStockChangedHandler: ((Item, Bool) -> Void)? = nil, onRefresh: @escaping () -> Void, onPaging: @escaping () -> Void, @ViewBuilder header: () -> HeaderView) {
         self._items = items
         self._isRefreshing = isRefreshing
         self.onItemStockChangedHandler = onItemStockChangedHandler
-        self.likeRepository = likeRepository
-        self.stockRepository = stockRepository
         self.onRefresh = onRefresh
         self.onPaging = onPaging
         self.headerView = header()
     }
 
     // headerを使わない場合
-    init(items: Binding<[Item]>, isRefreshing: Binding<Bool>, onItemStockChangedHandler: ((Item, Bool) -> Void)? = nil, likeRepository: LikeRepository, stockRepository: StockRepository, onRefresh: @escaping () -> Void, onPaging: @escaping () -> Void) where HeaderView == EmptyView {
+    init(items: Binding<[Item]>, isRefreshing: Binding<Bool>, onItemStockChangedHandler: ((Item, Bool) -> Void)? = nil, onRefresh: @escaping () -> Void, onPaging: @escaping () -> Void) where HeaderView == EmptyView {
         self._items = items
         self._isRefreshing = isRefreshing
         self.onItemStockChangedHandler = onItemStockChangedHandler
-        self.likeRepository = likeRepository
-        self.stockRepository = stockRepository
         self.onRefresh = onRefresh
         self.onPaging = onPaging
         self.headerView = EmptyView()
@@ -59,7 +54,7 @@ struct ItemListView<HeaderView: View>: View {
             headerView
 
             ForEach(items) { item in
-                ItemListItem(item: item, onItemStockChangedHandler: onItemStockChangedHandler, stockRepository: stockRepository, likeRepository: likeRepository)
+                ItemListItem(viewModel: ItemListItemViewModel(item: item, onItemStockChangedHandler: onItemStockChangedHandler, stockRepository: repositoryContainer.stockRepository, likeRepository: repositoryContainer.likeRepository))
             }
 
             HStack {
@@ -81,8 +76,8 @@ struct ItemListItem: View {
 
     // MARK: - Initializer
 
-    init(item: Item, onItemStockChangedHandler: ((Item, Bool) -> Void)? = nil, stockRepository: StockRepository, likeRepository: LikeRepository) {
-        self.viewModel = ItemListItemViewModel(item: item, onItemStockChangedHandler: onItemStockChangedHandler, stockRepository: stockRepository, likeRepository: likeRepository)
+    init(viewModel: ItemListItemViewModel) {
+        self.viewModel = viewModel
 
         // FIXME: ここだけ例外的にonAppearではなくinitでやってる
         // 1回だけのonAppearでやると、onAppearの後にListの更新がなぜか走り、checkしたステータスが初期化されてしまう
@@ -90,7 +85,7 @@ struct ItemListItem: View {
     }
 
     var body: some View {
-        NavigationLink(destination: ItemDetailView(item: viewModel.item, likeRepository: viewModel.likeRepository, stockRepository: viewModel.stockRepository)) {
+        NavigationLink(destination: ItemDetailView(viewModel: ItemDetailViewModel(item: viewModel.item, likeRepository: viewModel.likeRepository, stockRepository: viewModel.stockRepository))) {
             HStack {
                 ImageView(url: viewModel.item.user.profileImageUrl)
                     .frame(width: 40, height: 40)
@@ -149,6 +144,6 @@ struct ItemListView_Previews: PreviewProvider {
     @State static var isLoading = false
 
     static var previews: some View {
-        ItemListView(items: $items, isRefreshing: $isLoading, onItemStockChangedHandler: nil, likeRepository: LikeStubService(), stockRepository: StockStubService(), onRefresh: { }, onPaging: { })
+        ItemListView(items: $items, isRefreshing: $isLoading, onItemStockChangedHandler: nil, onRefresh: { }, onPaging: { })
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/ItemList/ItemListView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/ItemList/ItemListView.swift
@@ -146,5 +146,6 @@ struct ItemListView_Previews: PreviewProvider {
 
     static var previews: some View {
         ItemListView(items: $items, isRefreshing: $isLoading, onItemStockChangedHandler: nil, onRefresh: { }, onPaging: { })
+            .environmentObject(RepositoryContainerFactory.createStubs())
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/Launch/LaunchView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Launch/LaunchView.swift
@@ -11,28 +11,24 @@ struct LaunchView: View {
 
     // MARK: - Property
 
+    @EnvironmentObject var repositoryContainer: RepositoryContainer
     @EnvironmentObject var authState: AuthState
-
-    let likeRepository: LikeRepository
-    let authRepository: AuthRepository
-    let itemRepository: ItemRepository
-    let stockRepository: StockRepository
-    let tagRepository: TagRepository
 
     // MARK: - Body
 
     var body: some View {
         if authState.isSignedin {
-            MainView(likeRepository: likeRepository, authRepository: authRepository, itemRepository: itemRepository, stockRepository: stockRepository, tagRepository: tagRepository)
+            MainView()
         } else {
-            LoginView(authRepository: authRepository)
+            LoginView(viewModel: LoginViewModel(authRepository: repositoryContainer.authRepository))
         }
     }
 }
 
 struct LaunchView_Previews: PreviewProvider {
     static var previews: some View {
-        LaunchView(likeRepository: LikeStubService(), authRepository: AuthStubService(), itemRepository: ItemStubService(), stockRepository: StockStubService(), tagRepository: TagStubService())
+        LaunchView()
+            .environmentObject(RepositoryContainerFactory.createStubs())
             .environmentObject(AuthState(authRepository: AuthStubService()))
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/Login/LoginView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Login/LoginView.swift
@@ -18,8 +18,8 @@ struct LoginView: View {
 
     // MARK: - Initializer
 
-    init(authRepository: AuthRepository) {
-        viewModel = LoginViewModel(authRepository: authRepository)
+    init(viewModel: LoginViewModel) {
+        self.viewModel = viewModel
     }
 
     // MARK: - Body
@@ -42,6 +42,6 @@ struct LoginView: View {
 
 struct LoginView_Previews: PreviewProvider {
     static var previews: some View {
-        LoginView(authRepository: AuthStubService())
+        LoginView(viewModel: LoginViewModel(authRepository: AuthStubService()))
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/Login/LoginView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Login/LoginView.swift
@@ -43,5 +43,7 @@ struct LoginView: View {
 struct LoginView_Previews: PreviewProvider {
     static var previews: some View {
         LoginView(viewModel: LoginViewModel(authRepository: AuthStubService()))
+            .environmentObject(RepositoryContainerFactory.createStubs())
+            .environmentObject(AuthState(authRepository: AuthStubService()))
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/Main/MainView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Main/MainView.swift
@@ -45,5 +45,6 @@ struct MainView_Previews: PreviewProvider {
     static var previews: some View {
         MainView()
             .environmentObject(RepositoryContainerFactory.createStubs())
+            .environmentObject(AuthState(authRepository: AuthStubService()))
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/Main/MainView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Main/MainView.swift
@@ -11,32 +11,28 @@ struct MainView: View {
 
     // MARK: - Property
 
-    var likeRepository: LikeRepository
-    var authRepository: AuthRepository
-    var itemRepository: ItemRepository
-    var stockRepository: StockRepository
-    var tagRepository: TagRepository
+    @EnvironmentObject var repositoryContainer: RepositoryContainer
 
     // MARK: - Body
 
     var body: some View {
         TabView {
-            HomeView(itemRepository: itemRepository, likeRepository: likeRepository, stockRepository: stockRepository)
+            HomeView(viewModel: HomeViewModel(itemRepository: repositoryContainer.itemRepository))
                 .tabItem {
                     Image(systemName: "house")
                     Text("Home")
                 }
-            SearchView(tagRepository: tagRepository, itemRepository: itemRepository, likeRepository: likeRepository, stockRepository: stockRepository)
+            SearchView(viewModel: SearchViewModel(tagRepository: repositoryContainer.tagRepository))
                 .tabItem {
                     Image(systemName: "magnifyingglass")
                     Text("Search")
                 }
-            StockView(stockRepository: stockRepository, itemRepository: itemRepository, likeRepository: likeRepository)
+            StockView(viewModel: StockViewModel(stockRepository: repositoryContainer.stockRepository))
                 .tabItem {
                     Image(systemName: "folder")
                     Text("Stock")
                 }
-            ProfileView(authRepository: authRepository, itemRepository: itemRepository, likeRepository: likeRepository, stockRepository: stockRepository)
+            ProfileView(viewModel: ProfileViewModel(authRepository: repositoryContainer.authRepository, itemRepository: repositoryContainer.itemRepository))
                 .tabItem {
                     Image(systemName: "person")
                     Text("Profile")
@@ -47,6 +43,7 @@ struct MainView: View {
 
 struct MainView_Previews: PreviewProvider {
     static var previews: some View {
-        MainView(likeRepository: LikeStubService(), authRepository: AuthStubService(), itemRepository: ItemStubService(), stockRepository: StockStubService(), tagRepository: TagStubService())
+        MainView()
+            .environmentObject(RepositoryContainerFactory.createStubs())
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/Profile/ProfileView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Profile/ProfileView.swift
@@ -11,19 +11,16 @@ struct ProfileView: View {
 
     // MARK: - Property
 
+    @EnvironmentObject var repositoryContainer: RepositoryContainer
+
     @ObservedObject private var viewModel: ProfileViewModel
     @State private var isPresented = false
     @State private var isInitialOnAppear = true
 
-    let likeRepository: LikeRepository
-    let stockRepository: StockRepository
-
     // MARK: - Initializer
 
-    init(authRepository: AuthRepository, itemRepository: ItemRepository, likeRepository: LikeRepository, stockRepository: StockRepository) {
-        self.viewModel = ProfileViewModel(authRepository: authRepository, itemRepository: itemRepository)
-        self.likeRepository = likeRepository
-        self.stockRepository = stockRepository
+    init(viewModel: ProfileViewModel) {
+        self.viewModel = viewModel
     }
 
     // MARK: - Body
@@ -35,7 +32,7 @@ struct ProfileView: View {
                     VStack(spacing: 0) {
                         UserInformationView(user: user)
 
-                        ItemListView(items: $viewModel.items, isRefreshing: $viewModel.isRefreshing, onItemStockChangedHandler: nil, likeRepository: likeRepository, stockRepository: stockRepository, onRefresh: viewModel.fetchItems, onPaging: viewModel.fetchMoreItems)
+                        ItemListView(items: $viewModel.items, isRefreshing: $viewModel.isRefreshing, onItemStockChangedHandler: nil, onRefresh: viewModel.fetchItems, onPaging: viewModel.fetchMoreItems)
                     }
                 } else {
                     ProgressView()
@@ -56,7 +53,7 @@ struct ProfileView: View {
             }
         }
         .sheet(isPresented: $isPresented) {
-            SettingView(authRepository: viewModel.authRepository, isPresenting: $isPresented)
+            SettingView(isPresenting: $isPresented, viewModel: SettingViewModel(authRepository: repositoryContainer.authRepository))
         }
     }
 }
@@ -122,6 +119,6 @@ struct ContributionView: View {
 
 struct ProfileView_Previews: PreviewProvider {
     static var previews: some View {
-        ProfileView(authRepository: AuthStubService(), itemRepository: ItemStubService(), likeRepository: LikeStubService(), stockRepository: StockStubService())
+        ProfileView(viewModel: ProfileViewModel(authRepository: AuthStubService(), itemRepository: ItemStubService()))
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/Profile/ProfileView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Profile/ProfileView.swift
@@ -120,5 +120,7 @@ struct ContributionView: View {
 struct ProfileView_Previews: PreviewProvider {
     static var previews: some View {
         ProfileView(viewModel: ProfileViewModel(authRepository: AuthStubService(), itemRepository: ItemStubService()))
+            .environmentObject(RepositoryContainerFactory.createStubs())
+            .environmentObject(AuthState(authRepository: AuthStubService()))
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/Search/SearchView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Search/SearchView.swift
@@ -139,5 +139,6 @@ struct TagListView: View {
 struct SearchView_Previews: PreviewProvider {
     static var previews: some View {
         SearchView(viewModel: SearchViewModel(tagRepository: TagStubService()))
+            .environmentObject(RepositoryContainerFactory.createStubs())
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/Search/SearchView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Search/SearchView.swift
@@ -12,10 +12,7 @@ struct SearchView: View {
 
     // MARK: - Property
 
-    private let itemRepository: ItemRepository
-    private let likeRepository: LikeRepository
-    private let stockRepository: StockRepository
-    private let tagRepository: TagRepository
+    @EnvironmentObject var repositoryContainer: RepositoryContainer
     @ObservedObject private var viewModel: SearchViewModel
 
     @State var isEditing: Bool = false
@@ -26,12 +23,8 @@ struct SearchView: View {
 
     // MARK: - Initializer
 
-    init(tagRepository: TagRepository, itemRepository: ItemRepository, likeRepository: LikeRepository, stockRepository: StockRepository) {
-        self.viewModel = SearchViewModel(tagRepository: tagRepository)
-        self.itemRepository = itemRepository
-        self.likeRepository = likeRepository
-        self.stockRepository = stockRepository
-        self.tagRepository = tagRepository
+    init(viewModel: SearchViewModel) {
+        self.viewModel = viewModel
     }
 
     // MARK: - Body
@@ -39,7 +32,7 @@ struct SearchView: View {
     var body: some View {
         NavigationView {
             GeometryReader { geometry in
-                NavigationLink(destination: SearchResultView(searchType: .word(searchText), itemRepository: itemRepository, likeRepository: likeRepository, stockRepository: stockRepository, tagRepository: tagRepository), isActive: $isPush) { EmptyView() }
+                NavigationLink(destination: SearchResultView(viewModel: SearchResultViewModel(searchType: .word(searchText), itemRepository: repositoryContainer.itemRepository)), isActive: $isPush) { EmptyView() }
 
                 // ヘッダーも含めてスクロールさせたいが
                 // ListやCollectionViewのヘッダーが存在しないので
@@ -63,7 +56,7 @@ struct SearchView: View {
                         Spacer()
                     }
 
-                    TagListView(tags: viewModel.tags, itemRepository: itemRepository, likeRepository: likeRepository, stockRepository: stockRepository, tagRepository: tagRepository)
+                    TagListView(tags: viewModel.tags)
                         // scrollDisableが反応しないのでcontent以上の高さにしてスクロールできなくする
                         .height((geometry.size.width / 3) * 10 + 5)
                 }
@@ -115,16 +108,14 @@ struct KeywordListView: View {
 
 struct TagListView: View {
 
+    @EnvironmentObject var repositoryContainer: RepositoryContainer
+
     let tags: [ItemTag]
-    let itemRepository: ItemRepository
-    let likeRepository: LikeRepository
-    let stockRepository: StockRepository
-    let tagRepository: TagRepository
 
     var body: some View {
         GeometryReader { geometry in
             CollectionView(tags) { tag in
-                NavigationLink(destination: SearchResultView(searchType: .tag(tag), itemRepository: itemRepository, likeRepository: likeRepository, stockRepository: stockRepository, tagRepository: tagRepository)) {
+                NavigationLink(destination: SearchResultView(viewModel: SearchResultViewModel(searchType: .tag(tag), itemRepository: repositoryContainer.itemRepository))) {
                     ZStack {
                         ImageView(url: tag.iconUrl!)
 
@@ -147,6 +138,6 @@ struct TagListView: View {
 
 struct SearchView_Previews: PreviewProvider {
     static var previews: some View {
-        SearchView(tagRepository: TagStubService(), itemRepository: ItemStubService(), likeRepository: LikeStubService(), stockRepository: StockStubService())
+        SearchView(viewModel: SearchViewModel(tagRepository: TagStubService()))
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/SearchResult/Component/TagInformationView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/SearchResult/Component/TagInformationView.swift
@@ -11,13 +11,15 @@ struct TagInformationView: View {
 
     // MARK: - Property
 
+    @EnvironmentObject var repositoryContainer: RepositoryContainer
+
     @ObservedObject private var viewModel: TagInformationViewModel
     @State private var isInitialOnAppear = true
 
     // MARK: - Initializer
 
-    init(tag: ItemTag, tagRepository: TagRepository) {
-        self.viewModel = TagInformationViewModel(tag: tag, tagRepository: tagRepository)
+    init(viewModel: TagInformationViewModel) {
+        self.viewModel = viewModel
 
         /// FIXME: ItemListItemと同様にonAppearでやると再描画されて状態が上書きされる
         viewModel.checkIsFollowed()

--- a/Qiita_SwiftUI/Presentation/Screen/SearchResult/SearchResultView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/SearchResult/SearchResultView.swift
@@ -59,7 +59,9 @@ struct SearchResultView_Previews: PreviewProvider {
 
     static var previews: some View {
         SearchResultView(viewModel: SearchResultViewModel(searchType: .word("iOS"), itemRepository: ItemStubService()))
+            .environmentObject(RepositoryContainerFactory.createStubs())
 
         SearchResultView(viewModel: SearchResultViewModel(searchType: .tag(tag), itemRepository: ItemStubService()))
+            .environmentObject(RepositoryContainerFactory.createStubs())
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/SearchResult/SearchResultView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/SearchResult/SearchResultView.swift
@@ -11,20 +11,16 @@ struct SearchResultView: View {
 
     // MARK: - Property
 
+    @EnvironmentObject var repositoryContainer: RepositoryContainer
+
     @ObservedObject private var viewModel: SearchResultViewModel
-    private let likeRepository: LikeRepository
-    private let stockRepository: StockRepository
-    private let tagRepository: TagRepository
 
     @State private var isInitialOnAppear = true
 
     // MARK: - Initializer
 
-    init(searchType: SearchType, itemRepository: ItemRepository, likeRepository: LikeRepository, stockRepository: StockRepository, tagRepository: TagRepository) {
-        viewModel = SearchResultViewModel(searchType: searchType, itemRepository: itemRepository)
-        self.likeRepository = likeRepository
-        self.stockRepository = stockRepository
-        self.tagRepository = tagRepository
+    init(viewModel: SearchResultViewModel) {
+        self.viewModel = viewModel
     }
 
     // MARK: - Body
@@ -33,9 +29,9 @@ struct SearchResultView: View {
         /// FIXME: ItemListViewのHeaderが左寄せになっている問題
         /// 現在はSearchResultの方で幅を指定して対応
         GeometryReader { reader in
-            ItemListView(items: $viewModel.items, isRefreshing: $viewModel.isRefreshing, onItemStockChangedHandler: nil, likeRepository: likeRepository, stockRepository: stockRepository, onRefresh: viewModel.fetchItems, onPaging: viewModel.fetchMoreItems, header: {
+            ItemListView(items: $viewModel.items, isRefreshing: $viewModel.isRefreshing, onItemStockChangedHandler: nil, onRefresh: viewModel.fetchItems, onPaging: viewModel.fetchMoreItems, header: {
                 if case .tag(let tag) = viewModel.searchType {
-                    TagInformationView(tag: tag, tagRepository: tagRepository)
+                    TagInformationView(viewModel: TagInformationViewModel(tag: tag, tagRepository: repositoryContainer.tagRepository))
                         .frame(width: reader.size.width - 32)
                 }
             })
@@ -58,9 +54,12 @@ struct SearchResultView: View {
 }
 
 struct SearchResultView_Previews: PreviewProvider {
-    static var previews: some View {
-        SearchResultView(searchType: .word("iOS"), itemRepository: ItemStubService(), likeRepository: LikeStubService(), stockRepository: StockStubService(), tagRepository: TagStubService())
 
-        SearchResultView(searchType: .tag(ItemTag(iconUrl: URL(string: "https://avatars2.githubusercontent.com/u/44288050?v=4")!, followersCount: 10, id: "iOS", itemsCount: 10)), itemRepository: ItemStubService(), likeRepository: LikeStubService(), stockRepository: StockStubService(), tagRepository: TagStubService())
+    private static let tag = ItemTag(iconUrl: URL(string: "https://avatars2.githubusercontent.com/u/44288050?v=4")!, followersCount: 10, id: "iOS", itemsCount: 10)
+
+    static var previews: some View {
+        SearchResultView(viewModel: SearchResultViewModel(searchType: .word("iOS"), itemRepository: ItemStubService()))
+
+        SearchResultView(viewModel: SearchResultViewModel(searchType: .tag(tag), itemRepository: ItemStubService()))
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/Setting/SettingView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Setting/SettingView.swift
@@ -19,9 +19,9 @@ struct SettingView: View {
 
     // MARK: - Initializer
 
-    init(authRepository: AuthRepository, isPresenting: Binding<Bool>) {
+    init(isPresenting: Binding<Bool>, viewModel: SettingViewModel) {
         self._isPresenting = isPresenting
-        viewModel = SettingViewModel(authRepository: authRepository)
+        self.viewModel = viewModel
     }
 
     // MARK: - Body
@@ -74,7 +74,7 @@ struct SettingView_Previews: PreviewProvider {
     @State static var isPresenting: Bool = true
 
     static var previews: some View {
-        SettingView(authRepository: AuthStubService(), isPresenting: $isPresenting)
+        SettingView(isPresenting: $isPresenting, viewModel: SettingViewModel(authRepository: AuthStubService()))
             .environmentObject(AuthState(authRepository: AuthStubService()))
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/Stock/StockView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Stock/StockView.swift
@@ -41,5 +41,6 @@ struct StockView: View {
 struct StockView_Previews: PreviewProvider {
     static var previews: some View {
         StockView(viewModel: StockViewModel(stockRepository: StockStubService()))
+            .environmentObject(RepositoryContainerFactory.createStubs())
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/Stock/StockView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Stock/StockView.swift
@@ -11,25 +11,23 @@ struct StockView: View {
 
     // MARK: - Property
 
+    @EnvironmentObject var repositoryContainer: RepositoryContainer
+
     @ObservedObject private var viewModel: StockViewModel
-    private let itemRepository: ItemRepository
-    private let likeRepository: LikeRepository
 
     @State private var isInitialOnAppear = true
 
     // MARK: - Initializer
 
-    init(stockRepository: StockRepository, itemRepository: ItemRepository, likeRepository: LikeRepository) {
-        self.viewModel = StockViewModel(stockRepository: stockRepository)
-        self.itemRepository = itemRepository
-        self.likeRepository = likeRepository
+    init(viewModel: StockViewModel) {
+        self.viewModel = viewModel
     }
 
     // MARK: - Body
 
     var body: some View {
         NavigationView {
-            ItemListView(items: $viewModel.items, isRefreshing: $viewModel.isRefreshing, onItemStockChangedHandler: viewModel.onItemStockChangedHandler, likeRepository: likeRepository, stockRepository: viewModel.stockRepository, onRefresh: viewModel.fetchItems, onPaging: viewModel.fetchMoreItems)
+            ItemListView(items: $viewModel.items, isRefreshing: $viewModel.isRefreshing, onItemStockChangedHandler: viewModel.onItemStockChangedHandler, onRefresh: viewModel.fetchItems, onPaging: viewModel.fetchMoreItems)
                 .navigationBarTitle("Stock", displayMode: .inline)
         }.onAppear {
             if isInitialOnAppear {
@@ -42,6 +40,6 @@ struct StockView: View {
 
 struct StockView_Previews: PreviewProvider {
     static var previews: some View {
-        StockView(stockRepository: StockStubService(), itemRepository: ItemStubService(), likeRepository: LikeStubService())
+        StockView(viewModel: StockViewModel(stockRepository: StockStubService()))
     }
 }

--- a/Qiita_SwiftUI/Qiita_SwiftUIApp.swift
+++ b/Qiita_SwiftUI/Qiita_SwiftUIApp.swift
@@ -12,8 +12,9 @@ struct Qiita_SwiftUIApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     var body: some Scene {
         WindowGroup {
-            LaunchView(likeRepository: AppContainer.shared.likeRepository, authRepository: AppContainer.shared.authRepository, itemRepository: AppContainer.shared.itemRepository, stockRepository: AppContainer.shared.stockRepository, tagRepository: AppContainer.shared.tagRepository)
-                .environmentObject(AuthState(authRepository: AppContainer.shared.authRepository))
+            LaunchView()
+                .environmentObject(AppContainer.shared.repositoryContainer)
+                .environmentObject(AuthState(authRepository: AppContainer.shared.repositoryContainer.authRepository))
         }
     }
 }

--- a/Qiita_SwiftUI/Service/Stub/UserStubService.swift
+++ b/Qiita_SwiftUI/Service/Stub/UserStubService.swift
@@ -1,0 +1,18 @@
+//
+//  UserStubService.swift
+//  Qiita_SwiftUI
+//
+//  Created by kntk on 2021/09/13.
+//
+
+import Foundation
+import Combine
+
+final class UserStubService: UserRepository {
+
+    let user = User(id: "kntkymt", name: "kntkymt", description: "iOSエンジニアです", profileImageUrl: URL(string: "https://avatars2.githubusercontent.com/u/44288050?v=4")!, itemsCount: 10, followeesCount: 20, followersCount: 30)
+
+    func getUser(id: User.ID) -> AnyPublisher<User, Error> {
+        return Future { $0(.success(self.user)) }.eraseToAnyPublisher()
+    }
+}


### PR DESCRIPTION
## 概要
- Repositoryを`@main`から各画面にバケツリレーしていて汚かった/だるかったので修正する

## 実装
- `AppContainer`に存在する`Repository`をまとめた`RepositoryContainer`を作成
    - これを各画面に`.environmentObject()`を用いてDIする
- `View`の`init`を`Repository`ではなく`ViewModel`にすることでDIされた`RepositoryContainer`を元に`ViewModel`を生成できる
- EOは子Viewであれば伝わる
- PreviewではStubの`RepositoryContainer`をDIする
    - Previewした階層以下にStubが伝わり、StubでPreviewできて○