### PR TITLE
modifierをSwiftUIっぽくする

### DIFF
--- a/Qiita_SwiftUI.xcodeproj/project.pbxproj
+++ b/Qiita_SwiftUI.xcodeproj/project.pbxproj
@@ -66,6 +66,8 @@
 		E25E9A9326EE9F0B0090A0E3 /* RepositoryContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25E9A9226EE9F0B0090A0E3 /* RepositoryContainer.swift */; };
 		E25E9A9526EE9F320090A0E3 /* UserStubService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25E9A9426EE9F320090A0E3 /* UserStubService.swift */; };
 		E25E9AAA26F3D72C0090A0E3 /* FooterLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25E9AA926F3D72B0090A0E3 /* FooterLoadingView.swift */; };
+		E25E9AC326F63F280090A0E3 /* PullToRefresh.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25E9AC226F63F280090A0E3 /* PullToRefresh.swift */; };
+		E25E9AC626F6437C0090A0E3 /* Introspect in Frameworks */ = {isa = PBXBuildFile; productRef = E25E9AC526F6437C0090A0E3 /* Introspect */; };
 		E2729DE1264EC601009473D0 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DE0264EC601009473D0 /* HomeView.swift */; };
 		E2729DE3264ECA96009473D0 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DE2264ECA96009473D0 /* HomeViewModel.swift */; };
 		E2729DE6264ECDA7009473D0 /* ItemListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DE5264ECDA7009473D0 /* ItemListView.swift */; };
@@ -77,7 +79,6 @@
 		E2729DF5264F39DC009473D0 /* StockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DF4264F39DC009473D0 /* StockView.swift */; };
 		E2729DF7264F3A0F009473D0 /* StockViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DF6264F3A0F009473D0 /* StockViewModel.swift */; };
 		E2729DF9264F3ADC009473D0 /* StockStubService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DF8264F3ADC009473D0 /* StockStubService.swift */; };
-		E295D60B26D8AE4300246986 /* SwiftUIRefresh in Frameworks */ = {isa = PBXBuildFile; productRef = E295D60A26D8AE4300246986 /* SwiftUIRefresh */; };
 		E295D60D26D948AA00246986 /* WebViewRuleList.json in Resources */ = {isa = PBXBuildFile; fileRef = E295D60C26D948AA00246986 /* WebViewRuleList.json */; };
 		E295D60F26D9574800246986 /* ItemDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E295D60E26D9574800246986 /* ItemDetailViewModel.swift */; };
 		E295D61126D97A0800246986 /* LikeStubService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E295D61026D97A0800246986 /* LikeStubService.swift */; };
@@ -173,6 +174,7 @@
 		E25E9A9226EE9F0B0090A0E3 /* RepositoryContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryContainer.swift; sourceTree = "<group>"; };
 		E25E9A9426EE9F320090A0E3 /* UserStubService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserStubService.swift; sourceTree = "<group>"; };
 		E25E9AA926F3D72B0090A0E3 /* FooterLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FooterLoadingView.swift; sourceTree = "<group>"; };
+		E25E9AC226F63F280090A0E3 /* PullToRefresh.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PullToRefresh.swift; sourceTree = "<group>"; };
 		E2729DE0264EC601009473D0 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		E2729DE2264ECA96009473D0 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		E2729DE5264ECDA7009473D0 /* ItemListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemListView.swift; sourceTree = "<group>"; };
@@ -202,8 +204,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E295D60B26D8AE4300246986 /* SwiftUIRefresh in Frameworks */,
 				E20DD37D25FF47E600735B0A /* KeychainAccess in Frameworks */,
+				E25E9AC626F6437C0090A0E3 /* Introspect in Frameworks */,
 				E20DD36425FF460500735B0A /* Moya in Frameworks */,
 				E20DD38325FF483200735B0A /* SwiftyBeaver in Frameworks */,
 				E2BB277C2656B92100148F45 /* SwiftUIX in Frameworks */,
@@ -496,6 +498,7 @@
 				E2729DEA264F0D43009473D0 /* ImageView.swift */,
 				E2729DEF264F18F0009473D0 /* WebView.swift */,
 				E25E9AA926F3D72B0090A0E3 /* FooterLoadingView.swift */,
+				E25E9AC226F63F280090A0E3 /* PullToRefresh.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -604,7 +607,7 @@
 				E20DD38225FF483200735B0A /* SwiftyBeaver */,
 				E2729DE8264F0C82009473D0 /* FetchImage */,
 				E2BB277B2656B92100148F45 /* SwiftUIX */,
-				E295D60A26D8AE4300246986 /* SwiftUIRefresh */,
+				E25E9AC526F6437C0090A0E3 /* Introspect */,
 			);
 			productName = Qiita_SwiftUI;
 			productReference = E20DD2BF25FF325600735B0A /* Qiita_SwiftUI.app */;
@@ -683,7 +686,7 @@
 				E20DD38125FF483200735B0A /* XCRemoteSwiftPackageReference "SwiftyBeaver" */,
 				E2729DE7264F0C82009473D0 /* XCRemoteSwiftPackageReference "FetchImage" */,
 				E2BB277A2656B92100148F45 /* XCRemoteSwiftPackageReference "SwiftUIX" */,
-				E295D60926D8AE4300246986 /* XCRemoteSwiftPackageReference "SwiftUIRefresh" */,
+				E25E9AC426F6437C0090A0E3 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */,
 			);
 			productRefGroup = E20DD2C025FF325600735B0A /* Products */;
 			projectDirPath = "";
@@ -793,6 +796,7 @@
 				E20DD3AD25FF902300735B0A /* LoginView.swift in Sources */,
 				E2729DF7264F3A0F009473D0 /* StockViewModel.swift in Sources */,
 				E20DD31525FF403D00735B0A /* User.swift in Sources */,
+				E25E9AC326F63F280090A0E3 /* PullToRefresh.swift in Sources */,
 				E20DD3B225FF903B00735B0A /* MainView.swift in Sources */,
 				E2729DF0264F18F0009473D0 /* WebView.swift in Sources */,
 				E2729DE3264ECA96009473D0 /* HomeViewModel.swift in Sources */,
@@ -1144,20 +1148,20 @@
 				minimumVersion = 1.9.3;
 			};
 		};
+		E25E9AC426F6437C0090A0E3 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/siteline/SwiftUI-Introspect.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.1.3;
+			};
+		};
 		E2729DE7264F0C82009473D0 /* XCRemoteSwiftPackageReference "FetchImage" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/kean/FetchImage.git";
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 0.4.0;
-			};
-		};
-		E295D60926D8AE4300246986 /* XCRemoteSwiftPackageReference "SwiftUIRefresh" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/siteline/SwiftUIRefresh.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.0.3;
 			};
 		};
 		E2BB277A2656B92100148F45 /* XCRemoteSwiftPackageReference "SwiftUIX" */ = {
@@ -1186,15 +1190,15 @@
 			package = E20DD38125FF483200735B0A /* XCRemoteSwiftPackageReference "SwiftyBeaver" */;
 			productName = SwiftyBeaver;
 		};
+		E25E9AC526F6437C0090A0E3 /* Introspect */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E25E9AC426F6437C0090A0E3 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */;
+			productName = Introspect;
+		};
 		E2729DE8264F0C82009473D0 /* FetchImage */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = E2729DE7264F0C82009473D0 /* XCRemoteSwiftPackageReference "FetchImage" */;
 			productName = FetchImage;
-		};
-		E295D60A26D8AE4300246986 /* SwiftUIRefresh */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = E295D60926D8AE4300246986 /* XCRemoteSwiftPackageReference "SwiftUIRefresh" */;
-			productName = SwiftUIRefresh;
 		};
 		E2BB277B2656B92100148F45 /* SwiftUIX */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Qiita_SwiftUI.xcodeproj/project.pbxproj
+++ b/Qiita_SwiftUI.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		E25E9A8D26EE74350090A0E3 /* TagInformationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25E9A8C26EE74350090A0E3 /* TagInformationView.swift */; };
 		E25E9A9326EE9F0B0090A0E3 /* RepositoryContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25E9A9226EE9F0B0090A0E3 /* RepositoryContainer.swift */; };
 		E25E9A9526EE9F320090A0E3 /* UserStubService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25E9A9426EE9F320090A0E3 /* UserStubService.swift */; };
+		E25E9AAA26F3D72C0090A0E3 /* FooterLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25E9AA926F3D72B0090A0E3 /* FooterLoadingView.swift */; };
 		E2729DE1264EC601009473D0 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DE0264EC601009473D0 /* HomeView.swift */; };
 		E2729DE3264ECA96009473D0 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DE2264ECA96009473D0 /* HomeViewModel.swift */; };
 		E2729DE6264ECDA7009473D0 /* ItemListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DE5264ECDA7009473D0 /* ItemListView.swift */; };
@@ -171,6 +172,7 @@
 		E25E9A8C26EE74350090A0E3 /* TagInformationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagInformationView.swift; sourceTree = "<group>"; };
 		E25E9A9226EE9F0B0090A0E3 /* RepositoryContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryContainer.swift; sourceTree = "<group>"; };
 		E25E9A9426EE9F320090A0E3 /* UserStubService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserStubService.swift; sourceTree = "<group>"; };
+		E25E9AA926F3D72B0090A0E3 /* FooterLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FooterLoadingView.swift; sourceTree = "<group>"; };
 		E2729DE0264EC601009473D0 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		E2729DE2264ECA96009473D0 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		E2729DE5264ECDA7009473D0 /* ItemListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemListView.swift; sourceTree = "<group>"; };
@@ -493,6 +495,7 @@
 				E20DD3C525FF9E3A00735B0A /* SafariView.swift */,
 				E2729DEA264F0D43009473D0 /* ImageView.swift */,
 				E2729DEF264F18F0009473D0 /* WebView.swift */,
+				E25E9AA926F3D72B0090A0E3 /* FooterLoadingView.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -752,6 +755,7 @@
 				E20DD34825FF44BA00735B0A /* Auth.swift in Sources */,
 				E20DD33325FF40FC00735B0A /* LikeService.swift in Sources */,
 				E20DD30725FF3EAA00735B0A /* AppContext.swift in Sources */,
+				E25E9AAA26F3D72C0090A0E3 /* FooterLoadingView.swift in Sources */,
 				E2BB27812656C3E400148F45 /* SearchResultViewModel.swift in Sources */,
 				E20DD32425FF40EE00735B0A /* LikeRepository.swift in Sources */,
 				E2729DEE264F15C4009473D0 /* ItemDetailView.swift in Sources */,

--- a/Qiita_SwiftUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Qiita_SwiftUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -137,15 +137,6 @@
         }
       },
       {
-        "package": "SwiftUIRefresh",
-        "repositoryURL": "https://github.com/siteline/SwiftUIRefresh.git",
-        "state": {
-          "branch": null,
-          "revision": "fa8fac7b5eb5c729983a8bef65f094b5e0d12014",
-          "version": "0.0.3"
-        }
-      },
-      {
         "package": "SwiftUIX",
         "repositoryURL": "https://github.com/SwiftUIX/SwiftUIX.git",
         "state": {

--- a/Qiita_SwiftUI/Presentation/Common/FooterLoadingView.swift
+++ b/Qiita_SwiftUI/Presentation/Common/FooterLoadingView.swift
@@ -1,0 +1,83 @@
+//
+//  FooterLoadingView.swift
+//  Qiita_SwiftUI
+//
+//  Created by kntk on 2021/09/17.
+//
+
+import SwiftUI
+import Introspect
+
+private struct FooterLoadingView: UIViewRepresentable {
+
+    // MARK: - Property
+
+    let onReachBottom: () -> Void
+    @State private var observer: NSKeyValueObservation?
+
+    // MARK: - Public
+
+    public func makeUIView(context: UIViewRepresentableContext<FooterLoadingView>) -> UIView {
+        let view = UIView(frame: .zero)
+        view.isHidden = true
+        view.isUserInteractionEnabled = false
+        return view
+    }
+
+    public func updateUIView(_ uiView: UIView, context: UIViewRepresentableContext<FooterLoadingView>) {
+
+        DispatchQueue.main.asyncAfter(deadline: .now()) {
+
+            guard let tableView = self.tableView(entry: uiView) else {
+                return
+            }
+
+            observer = tableView.observe(\.contentOffset, changeHandler: { tableView, newValue in
+                let visibleHeight = tableView.frame.height - tableView.contentInset.top - tableView.contentInset.bottom
+                let y = tableView.contentOffset.y + tableView.contentInset.top
+                let threshold = max(0.0, tableView.contentSize.height - visibleHeight)
+
+                if y > threshold {
+                    startFooterLoading(tableView: tableView)
+                    onReachBottom()
+                }
+            })
+        }
+    }
+
+    // MARK: - Private
+
+    private func tableView(entry: UIView) -> UITableView? {
+
+        // Search in ancestors
+        if let tableView = Introspect.findAncestor(ofType: UITableView.self, from: entry) {
+            return tableView
+        }
+
+        guard let viewHost = Introspect.findViewHost(from: entry) else {
+            return nil
+        }
+
+        // Search in siblings
+        return Introspect.previousSibling(containing: UITableView.self, from: viewHost)
+    }
+
+    private func startFooterLoading(tableView: UITableView) {
+        let indicatorView = UIActivityIndicatorView()
+        indicatorView.style = .medium
+        indicatorView.backgroundColor = .secondarySystemGroupedBackground
+
+        indicatorView.color = .systemGray
+        indicatorView.frame.size.height = 50
+        indicatorView.isHidden = false
+        tableView.tableFooterView = indicatorView
+        indicatorView.startAnimating()
+    }
+}
+
+extension View {
+    public func footerLoading(onReachBottom: @escaping () -> Void) -> some View {
+        return overlay(FooterLoadingView(onReachBottom: onReachBottom)
+                        .frame(width: 0, height: 0))
+    }
+}

--- a/Qiita_SwiftUI/Presentation/Common/PullToRefresh.swift
+++ b/Qiita_SwiftUI/Presentation/Common/PullToRefresh.swift
@@ -1,0 +1,100 @@
+//
+//  PullToRefresh.swift
+//  Qiita_SwiftUI
+//
+// https://github.com/siteline/SwiftUIRefresh/blob/master/LICENSE
+
+import SwiftUI
+import Introspect
+
+private struct PullToRefresh: UIViewRepresentable {
+
+    public class Coordinator {
+        let onRefresh: () -> Void
+        let isShowing: Binding<Bool>
+
+        init(onRefresh: @escaping () -> Void, isShowing: Binding<Bool>) {
+            self.onRefresh = onRefresh
+            self.isShowing = isShowing
+        }
+
+        @objc
+        func onValueChanged() {
+            isShowing.wrappedValue = true
+            onRefresh()
+        }
+    }
+
+    // MARK: - Property
+
+    @Binding private var isShowing: Bool
+    private let onRefresh: () -> Void
+
+    // MARK: - Initializer
+
+    public init(isShowing: Binding<Bool>, onRefresh: @escaping () -> Void) {
+        _isShowing = isShowing
+        self.onRefresh = onRefresh
+    }
+
+    // MARK: - Public
+
+    public func makeUIView(context: UIViewRepresentableContext<PullToRefresh>) -> UIView {
+        let view = UIView(frame: .zero)
+        view.isHidden = true
+        view.isUserInteractionEnabled = false
+        return view
+    }
+
+    public func updateUIView(_ uiView: UIView, context: UIViewRepresentableContext<PullToRefresh>) {
+
+        DispatchQueue.main.asyncAfter(deadline: .now()) {
+            guard let tableView = self.tableView(entry: uiView) else {
+                return
+            }
+
+            if let refreshControl = tableView.refreshControl {
+                if self.isShowing {
+                    refreshControl.beginRefreshing()
+                } else {
+                    refreshControl.endRefreshing()
+                }
+                return
+            }
+
+            let refreshControl = UIRefreshControl()
+            refreshControl.addTarget(context.coordinator, action: #selector(Coordinator.onValueChanged), for: .valueChanged)
+            tableView.refreshControl = refreshControl
+        }
+    }
+
+    public func makeCoordinator() -> Coordinator {
+        return Coordinator(onRefresh: onRefresh, isShowing: $isShowing)
+    }
+
+    // MARK: - Private
+
+    private func tableView(entry: UIView) -> UITableView? {
+
+        // Search in ancestors
+        if let tableView = Introspect.findAncestor(ofType: UITableView.self, from: entry) {
+            return tableView
+        }
+
+        guard let viewHost = Introspect.findViewHost(from: entry) else {
+            return nil
+        }
+
+        // Search in siblings
+        return Introspect.previousSibling(containing: UITableView.self, from: viewHost)
+    }
+}
+
+extension View {
+    public func pullToRefresh(isShowing: Binding<Bool>, onRefresh: @escaping () -> Void) -> some View {
+        return overlay(
+            PullToRefresh(isShowing: isShowing, onRefresh: onRefresh)
+                .frame(width: 0, height: 0)
+        )
+    }
+}

--- a/Qiita_SwiftUI/Presentation/Screen/ItemList/ItemListView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/ItemList/ItemListView.swift
@@ -58,17 +58,10 @@ struct ItemListView<HeaderView: View>: View {
             ForEach(items) { item in
                 ItemListItem(viewModel: ItemListItemViewModel(item: item, onItemStockChangedHandler: onItemStockChangedHandler, stockRepository: repositoryContainer.stockRepository, likeRepository: repositoryContainer.likeRepository))
             }
-
-            HStack {
-                Spacer()
-                ProgressView()
-                    .onAppear {
-                        onPaging()
-                    }
-                Spacer()
-            }
-        }.listStyle(PlainListStyle())
+        }
+        .listStyle(PlainListStyle())
         .pullToRefresh(isShowing: $isRefreshing, onRefresh: onRefresh)
+        .footerLoading { onPaging() }
     }
 }
 

--- a/Qiita_SwiftUI/Presentation/Screen/ItemList/ItemListView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/ItemList/ItemListView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import SwiftUIRefresh
 
 struct ItemListView<HeaderView: View>: View {
 


### PR DESCRIPTION
## 概要
- SwftUIのListや自分が作ったViewに対して`.なんちゃら`ってやることで値の設定をしたい
    - FooterLoadingをList { }.onPaging()みたいな感じでやりたい
    - itemListViewへのハンドラーの登録も.なんちゃらでやれるといいかも
    - Listのヘッダーも.headerにする?

## 実装
### FooterLoadingをList { }.onPaging()みたいな感じでやりたい
- `SwiftUIRrfresh`を参考に実装
- Listの内部仕様がUITableViewっぽく(?)、UITableViewのfooterを使う
    - SwiftUIが実装くれてない部分を実装すると考えれば問題ないが、SwiftUIからUIKitの実装に退化しているといえばそう
    - とりあえず綺麗にはなったので採用

### itemListViewへの`onRefresh`などのハンドラーの登録も.なんちゃらでやれるといいかも
- `@Environment`でやってるっぽい
    - https://software.small-desk.com/development/2020/10/19/swiftui-my-own-environment/ 
- ライブラリならともかく、(ある程度再利用するViewではあるが)普通のViewでEnvironmentを定義するちょっと違う気がするのでとりあえずパス(？)

### ヘッダーを.headerにする?
- SwiftUIの思想的に、.なんちゃらで指定するのは設定値やハンドラー程度であり、Viewそのものを入れるのは違う気がするのでとりあえずパス

### SwiftUIRefresh廃止、Introspectを入れる
- `FooterLoading`を実装して`SwiftUIRefresh`を自分で書けるようになったので自前に変更
    - 自前といっても元から大して変わってないので一応ライセンスへのURLを貼っといた、これでいいのかな？
- `Introspect`というライブラリは必要だったので追加で入れる