### PR TITLE
CombineからConcurrencyに移行

### DIFF
--- a/Qiita_SwiftUI.xcodeproj/project.pbxproj
+++ b/Qiita_SwiftUI.xcodeproj/project.pbxproj
@@ -965,7 +965,7 @@
 				DEVELOPMENT_TEAM = B825Q6Y75U;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Qiita_SwiftUI/Configuration/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -986,7 +986,7 @@
 				DEVELOPMENT_TEAM = B825Q6Y75U;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Qiita_SwiftUI/Configuration/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1169,7 +1169,7 @@
 			repositoryURL = "https://github.com/SwiftUIX/SwiftUIX.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.0.6;
+				minimumVersion = 0.0.9;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Qiita_SwiftUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Qiita_SwiftUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -141,8 +141,8 @@
         "repositoryURL": "https://github.com/SwiftUIX/SwiftUIX.git",
         "state": {
           "branch": null,
-          "revision": "e0fd9ff48354a447d5dccdb4b485a69b63688e48",
-          "version": "0.0.6"
+          "revision": "05f6b13abc47d6f605bc2c253c7cb7e54dfe7ff2",
+          "version": "0.0.9"
         }
       },
       {

--- a/Qiita_SwiftUI/Network/API.swift
+++ b/Qiita_SwiftUI/Network/API.swift
@@ -7,7 +7,6 @@
 
 import Moya
 import Foundation
-import Combine
 
 final class API {
 
@@ -29,29 +28,34 @@ final class API {
 
     // MARK: - Public
 
-   func call<T: Decodable, Target: TargetType>(_ request: Target) -> Future<T, Error> {
-        let target = MultiTarget(request)
-        return Future { resolver in
+    func call<T: Decodable, Target: TargetType>(_ request: Target) async throws -> T {
+        return try await withCheckedThrowingContinuation { continuation in
+            let target = MultiTarget(request)
             self.provider.request(target) { response in
                 switch response {
                 case .success(let result):
                     do {
                         // FIXME: 204の扱い
                         if result.statusCode == 204 {
-                            guard let decoded = VoidModel() as? T else { throw NetworkingError.network }
-                            resolver(.success(decoded))
+                            guard let decoded = VoidModel() as? T else {
+                                continuation.resume(throwing: NetworkingError.network)
+                                return
+                            }
+
+                            continuation.resume(returning: decoded)
                         } else {
-                            resolver(.success(try self.decoder.decode(T.self, from: result.data)))
+                            continuation.resume(returning: try self.decoder.decode(T.self, from: result.data))
                         }
                     } catch {
-                        resolver(.failure(error))
+                        continuation.resume(throwing: error)
                     }
+
                 case .failure(let error):
-                    resolver(.failure(NetworkingError(error: error)))
+                    continuation.resume(throwing: NetworkingError(error: error))
                 }
-            }
-        }
-    }
+           }
+       }
+   }
 
     // MARK: - Initializer
 

--- a/Qiita_SwiftUI/Network/Auth.swift
+++ b/Qiita_SwiftUI/Network/Auth.swift
@@ -5,9 +5,7 @@
 //  Created by kntk on 2021/03/15.
 //
 
-import SafariServices
 import Foundation
-import Combine
 
 final class Auth {
 
@@ -17,19 +15,13 @@ final class Auth {
 
     // MARK: - Property
 
-    private var resolver: ((Result<AuthModel, Error>) -> Void)!
+    private var continuation: CheckedContinuation<AuthModel, Error>!
 
     @KeyChain(key: "accessToken")
     var accessToken: String?
 
-    private var cancellables = [AnyCancellable]()
-
     var isSignedin: Bool {
         return accessToken != nil
-    }
-
-    var currentUser: AnyPublisher<User, Error> {
-        return API.shared.call(AuthTarget.getAccount).eraseToAnyPublisher()
     }
 
     // MARK: - Public
@@ -37,36 +29,34 @@ final class Auth {
     func handleDeepLink(url: URL) {
         let parameters = url.queryParameters
         guard let code = parameters["code"] else {
-            resolver(.failure(NetworkingError.internal(message: "there is no parameter named code in this deeplink")))
+            continuation.resume(throwing: NetworkingError.internal(message: "there is no parameter named code in this deeplink"))
             return
         }
 
-        (API.shared.call(AuthTarget.getAccessToken(code: code)) as Future<AuthModel, Error>)
-            .receive(on: DispatchQueue.main)
-            .sink(receiveCompletion: { completion in
-                switch completion {
-                case .finished:
-                    break
-                case .failure(let error):
-                    Logger.error(error)
-                    self.resolver(.failure(error))
-                }
-            }, receiveValue: { auth in
-                self.accessToken = auth.token
-                self.resolver(.success(auth))
-            }).store(in: &cancellables)
+        Task {
+            do {
+                let authModel = try await API.shared.call(AuthTarget.getAccessToken(code: code)) as AuthModel
+                self.accessToken = authModel.token
+                continuation.resume(returning: authModel)
+            } catch {
+                continuation.resume(throwing: error)
+            }
+        }
     }
 
-    func signin() -> AnyPublisher<AuthModel, Error> {
-        return Future { resolver in
-            self.resolver = resolver
-        }.eraseToAnyPublisher()
+    func getCurrentUser() async throws -> User {
+        return try await API.shared.call(AuthTarget.getAccount)
     }
 
-    func signout() -> AnyPublisher<Void, Error> {
-        let result: Future<VoidModel, Error> = API.shared.call(AuthTarget.deleteAccessToken(accessToken: accessToken ?? "accessToken not found"))
+    func signin() async throws -> AuthModel {
+        return try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
 
-        return result.map { _ in self.accessToken = nil }.eraseToAnyPublisher()
+    func signout() async throws -> Void {
+        try await API.shared.call(AuthTarget.deleteAccessToken(accessToken: accessToken ?? "accessToken not found")) as VoidModel
+        accessToken = nil
     }
 
     // MARK: - Initializer

--- a/Qiita_SwiftUI/Network/Auth.swift
+++ b/Qiita_SwiftUI/Network/Auth.swift
@@ -55,7 +55,7 @@ final class Auth {
     }
 
     func signout() async throws -> Void {
-        try await API.shared.call(AuthTarget.deleteAccessToken(accessToken: accessToken ?? "accessToken not found")) as VoidModel
+        _ = try await API.shared.call(AuthTarget.deleteAccessToken(accessToken: accessToken ?? "accessToken not found")) as VoidModel
         accessToken = nil
     }
 

--- a/Qiita_SwiftUI/Presentation/Screen/Home/HomeViewModel.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Home/HomeViewModel.swift
@@ -6,8 +6,8 @@
 //
 
 import Foundation
-import Combine
 
+@MainActor
 final class HomeViewModel: ObservableObject {
 
     // MARK: - Property
@@ -19,7 +19,6 @@ final class HomeViewModel: ObservableObject {
     private var isPageLoading = false
 
     private let itemRepository: ItemRepository
-    private var cancellables = [AnyCancellable]()
 
     // MARK: - Initializer
 
@@ -29,40 +28,26 @@ final class HomeViewModel: ObservableObject {
 
     // MARK: - Public
 
-    func fetchItems() {
-        itemRepository.getItems(page: 1)
-            .receive(on: DispatchQueue.main)
-            .sink(receiveCompletion: { completion in
-                self.isRefreshing = false
-                switch completion {
-                case .finished:
-                    break
-                case .failure(let error):
-                    Logger.error(error)
-                }
-            }, receiveValue: { items in
-                self.page = 1
-                self.items = items
-            }).store(in: &cancellables)
+    func fetchItems() async {
+        do {
+            items = try await itemRepository.getItems(page: 1)
+            page = 1
+        } catch {
+            Logger.error(error)
+        }
+        isRefreshing = false
     }
 
-    func fetchMoreItems() {
+    func fetchMoreItems() async {
         if isPageLoading { return }
         isPageLoading = true
-        itemRepository.getItems(page: page + 1)
-            .receive(on: DispatchQueue.main)
-            .sink(receiveCompletion: { completion in
-                self.isRefreshing = false
-                self.isPageLoading = false
-                switch completion {
-                case .finished:
-                    break
-                case .failure(let error):
-                    Logger.error(error)
-                }
-            }, receiveValue: { items in
-                self.page += 1
-                self.items += items
-            }).store(in: &cancellables)
+        do {
+            items += try await itemRepository.getItems(page: page + 1)
+            page += 1
+        } catch {
+            Logger.error(error)
+        }
+        isRefreshing = false
+        isPageLoading = false
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/ItemDetail/ItemDetailView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/ItemDetail/ItemDetailView.swift
@@ -12,14 +12,14 @@ struct ItemDetailView: View {
 
     // MARK: - Property
 
-    @ObservedObject private var viewModel: ItemDetailViewModel
+    @StateObject private var viewModel: ItemDetailViewModel
     @State private var shareSheetPresented = false
     @State private var isInitialOnAppear = true
 
     // MARK: - Initializer
 
     init(viewModel: ItemDetailViewModel) {
-        self.viewModel = viewModel
+        self._viewModel = StateObject(wrappedValue: viewModel)
     }
 
     // MARK: - Body
@@ -34,7 +34,11 @@ struct ItemDetailView: View {
 
                 HStack(spacing: 36) {
                     if viewModel.isLiked {
-                        Button(systemImage: .handThumbsupFill, action: { viewModel.disLike() })
+                        Button(systemImage: .handThumbsupFill, action: {
+                            Task {
+                                await viewModel.disLike()
+                            }
+                        })
                             .frame(width: 44, height: 44)
                             .imageScale(.large)
                             .border(Color("brand"), width: 1, cornerRadius: 22)
@@ -42,7 +46,11 @@ struct ItemDetailView: View {
                             .background(Color("brand"))
                             .cornerRadius(22)
                     } else {
-                        Button(systemImage: .handThumbsup, action: { viewModel.like() })
+                        Button(systemImage: .handThumbsup, action: {
+                            Task {
+                                await viewModel.like()
+                            }
+                        })
                             .frame(width: 44, height: 44)
                             .imageScale(.large)
                             .border(Color("brand"), width: 1, cornerRadius: 22)
@@ -52,7 +60,11 @@ struct ItemDetailView: View {
                     }
 
                     if viewModel.isStocked {
-                        Button(systemImage: .folderFill, action: { viewModel.unStock() })
+                        Button(systemImage: .folderFill, action: {
+                            Task {
+                                await viewModel.unStock()
+                            }
+                        })
                             .frame(width: 44, height: 44)
                             .imageScale(.large)
                             .border(Color("brand"), width: 1, cornerRadius: 22)
@@ -60,7 +72,11 @@ struct ItemDetailView: View {
                             .background(Color("brand"))
                             .cornerRadius(22)
                     } else {
-                        Button(systemImage: .folder, action: { viewModel.stock() })
+                        Button(systemImage: .folder, action: {
+                            Task {
+                                await viewModel.stock()
+                            }
+                        })
                             .frame(width: 44, height: 44)
                             .imageScale(.large)
                             .border(Color("brand"), width: 1, cornerRadius: 22)
@@ -81,8 +97,9 @@ struct ItemDetailView: View {
             }.frame(height: 60, alignment: .center)
         }.onAppear {
             if isInitialOnAppear {
-                viewModel.checkIsLiked()
-                viewModel.checkIsStocked()
+                Task {
+                    await (viewModel.checkIsLiked(), viewModel.checkIsStocked())
+                }
                 
                 isInitialOnAppear = false
             }

--- a/Qiita_SwiftUI/Presentation/Screen/ItemDetail/ItemDetailView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/ItemDetail/ItemDetailView.swift
@@ -39,24 +39,24 @@ struct ItemDetailView: View {
                                 await viewModel.disLike()
                             }
                         })
-                            .frame(width: 44, height: 44)
-                            .imageScale(.large)
-                            .border(Color("brand"), width: 1, cornerRadius: 22)
-                            .foregroundColor(Color.white)
-                            .background(Color("brand"))
-                            .cornerRadius(22)
+                        .frame(width: 44, height: 44)
+                        .imageScale(.large)
+                        .border(Color("brand"), width: 1, cornerRadius: 22)
+                        .foregroundColor(Color.white)
+                        .background(Color("brand"))
+                        .cornerRadius(22)
                     } else {
                         Button(systemImage: .handThumbsup, action: {
                             Task {
                                 await viewModel.like()
                             }
                         })
-                            .frame(width: 44, height: 44)
-                            .imageScale(.large)
-                            .border(Color("brand"), width: 1, cornerRadius: 22)
-                            .foregroundColor(Color("brand"))
-                            .background(Color.clear)
-                            .cornerRadius(22)
+                        .frame(width: 44, height: 44)
+                        .imageScale(.large)
+                        .border(Color("brand"), width: 1, cornerRadius: 22)
+                        .foregroundColor(Color("brand"))
+                        .background(Color.clear)
+                        .cornerRadius(22)
                     }
 
                     if viewModel.isStocked {
@@ -65,24 +65,24 @@ struct ItemDetailView: View {
                                 await viewModel.unStock()
                             }
                         })
-                            .frame(width: 44, height: 44)
-                            .imageScale(.large)
-                            .border(Color("brand"), width: 1, cornerRadius: 22)
-                            .foregroundColor(Color.white)
-                            .background(Color("brand"))
-                            .cornerRadius(22)
+                        .frame(width: 44, height: 44)
+                        .imageScale(.large)
+                        .border(Color("brand"), width: 1, cornerRadius: 22)
+                        .foregroundColor(Color.white)
+                        .background(Color("brand"))
+                        .cornerRadius(22)
                     } else {
                         Button(systemImage: .folder, action: {
                             Task {
                                 await viewModel.stock()
                             }
                         })
-                            .frame(width: 44, height: 44)
-                            .imageScale(.large)
-                            .border(Color("brand"), width: 1, cornerRadius: 22)
-                            .foregroundColor(Color("brand"))
-                            .background(Color.clear)
-                            .cornerRadius(22)
+                        .frame(width: 44, height: 44)
+                        .imageScale(.large)
+                        .border(Color("brand"), width: 1, cornerRadius: 22)
+                        .foregroundColor(Color("brand"))
+                        .background(Color.clear)
+                        .cornerRadius(22)
                     }
 
                     Button(systemImage: .squareAndArrowUp, action: { shareSheetPresented.toggle() })

--- a/Qiita_SwiftUI/Presentation/Screen/ItemDetail/ItemDetailViewModel.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/ItemDetail/ItemDetailViewModel.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 import SwiftUI
-import Combine
 
+@MainActor
 final class ItemDetailViewModel: ObservableObject, Identifiable {
 
     // MARK: - Property
@@ -19,7 +19,6 @@ final class ItemDetailViewModel: ObservableObject, Identifiable {
 
     private let likeRepository: LikeRepository
     private let stockRepository: StockRepository
-    private var cancellables = [AnyCancellable]()
 
     // MARK: - Initializer
 
@@ -31,99 +30,63 @@ final class ItemDetailViewModel: ObservableObject, Identifiable {
 
     // MARK: - Public
 
-    func like() {
+    func like() async {
         isLiked = true
-        likeRepository.like(id: item.id)
-            .receive(on: DispatchQueue.main)
-            .sink(receiveCompletion: { completion in
-                switch completion {
-                case .finished:
-                    break
-                case .failure(let error):
-                    self.isLiked = false
-                    Logger.error(error)
-                }
-            }, receiveValue: { _ in
-            }).store(in: &cancellables)
+        do {
+            _ = try await likeRepository.like(id: item.id)
+        } catch {
+            isLiked = false
+            Logger.error(error)
+        }
     }
 
-    func disLike() {
+    func disLike() async {
         isLiked = false
-        likeRepository.unlike(id: item.id)
-            .receive(on: DispatchQueue.main)
-            .sink(receiveCompletion: { completion in
-                switch completion {
-                case .finished:
-                    break
-                case .failure(let error):
-                    self.isLiked = true
-                    Logger.error(error)
-                }
-            }, receiveValue: { _ in
-            }).store(in: &cancellables)
+        do {
+            _ = try await likeRepository.unlike(id: item.id)
+        } catch {
+            isLiked = true
+            Logger.error(error)
+        }
     }
 
-    func stock() {
+    func stock() async {
         isStocked = true
-        stockRepository.stock(id: item.id)
-            .receive(on: DispatchQueue.main)
-            .sink(receiveCompletion: { completion in
-                switch completion {
-                case .finished:
-                    break
-                case .failure(let error):
-                    self.isStocked = false
-                    Logger.error(error)
-                }
-            }, receiveValue: { _ in
-            }).store(in: &cancellables)
+        do {
+            _ = try await stockRepository.stock(id: item.id)
+        } catch {
+            isStocked = false
+            Logger.error(error)
+        }
     }
 
-    func unStock() {
+    func unStock() async {
         isStocked = false
-        stockRepository.unstock(id: item.id)
-            .receive(on: DispatchQueue.main)
-            .sink(receiveCompletion: { completion in
-                switch completion {
-                case .finished:
-                    break
-                case .failure(let error):
-                    self.isStocked = true
-                    Logger.error(error)
-                }
-            }, receiveValue: { _ in
-            }).store(in: &cancellables)
+        do {
+            _ = try await stockRepository.unstock(id: item.id)
+        } catch {
+            isStocked = true
+            Logger.error(error)
+        }
     }
 
-    func checkIsLiked() {
-        likeRepository.checkIsLiked(id: item.id)
-            .receive(on: DispatchQueue.main)
-            .sink(receiveCompletion: { completion in
-                switch completion {
-                case .finished:
-                    break
-                case .failure(let error):
-                    self.isLiked = false
-                    Logger.error(error)
-                }
-            }, receiveValue: { _ in
-                self.isLiked = true
-            }).store(in: &cancellables)
+    func checkIsLiked() async {
+        do {
+            _ = try await likeRepository.checkIsLiked(id: item.id)
+            isLiked = true
+        } catch {
+            isLiked = false
+            Logger.error(error)
+        }
     }
 
-    func checkIsStocked() {
-        stockRepository.checkIsStocked(id: item.id)
-            .receive(on: DispatchQueue.main)
-            .sink(receiveCompletion: { completion in
-                switch completion {
-                case .finished:
-                    break
-                case .failure(let error):
-                    self.isStocked = false
-                    Logger.error(error)
-                }
-            }, receiveValue: { _ in
-                self.isStocked = true
-            }).store(in: &cancellables)
+    func checkIsStocked() async {
+        do {
+            _ = try await stockRepository.checkIsStocked(id: item.id)
+            isStocked = true
+        } catch {
+            isStocked = false
+            Logger.error(error)
+        }
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/ItemList/ItemListView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/ItemList/ItemListView.swift
@@ -71,16 +71,12 @@ struct ItemListItem: View {
     @EnvironmentObject var repositoryContainer: RepositoryContainer
     @StateObject private var viewModel: ItemListItemViewModel
 
+    @State private var isInitialOnAppear = true
+
     // MARK: - Initializer
 
     init(viewModel: ItemListItemViewModel) {
         self._viewModel = StateObject(wrappedValue: viewModel)
-
-        // FIXME: ここだけ例外的にonAppearではなくinitでやってる
-        // 1回だけのonAppearでやると、onAppearの後にListの更新がなぜか走り、checkしたステータスが初期化されてしまう
-        Task {
-            await viewModel.checkIsStocked()
-        }
     }
 
     // MARK: - Body
@@ -143,6 +139,13 @@ struct ItemListItem: View {
                         .cornerRadius(16)
                 }
             }.padding(.vertical, 8)
+        }.onAppear {
+            if isInitialOnAppear {
+                Task {
+                    await viewModel.checkIsStocked()
+                }
+                isInitialOnAppear = false
+            }
         }
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/ItemList/ItemListView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/ItemList/ItemListView.swift
@@ -69,16 +69,18 @@ struct ItemListItem: View {
     // MARK: - Property
 
     @EnvironmentObject var repositoryContainer: RepositoryContainer
-    @ObservedObject private var viewModel: ItemListItemViewModel
+    @StateObject private var viewModel: ItemListItemViewModel
 
     // MARK: - Initializer
 
     init(viewModel: ItemListItemViewModel) {
-        self.viewModel = viewModel
+        self._viewModel = StateObject(wrappedValue: viewModel)
 
         // FIXME: ここだけ例外的にonAppearではなくinitでやってる
         // 1回だけのonAppearでやると、onAppearの後にListの更新がなぜか走り、checkしたステータスが初期化されてしまう
-        viewModel.checkIsStocked()
+        Task {
+            await viewModel.checkIsStocked()
+        }
     }
 
     // MARK: - Body
@@ -115,7 +117,11 @@ struct ItemListItem: View {
                 // Image.onTapGesture
                 if viewModel.isStocked {
                     Image(systemName: .folderFill)
-                        .onTapGesture { viewModel.unStock() }
+                        .onTapGesture {
+                            Task {
+                                await viewModel.unStock()
+                            }
+                        }
                         .frame(width: 32, height: 32)
                         .imageScale(.medium)
                         .border(Color("brand"), width: 1, cornerRadius: 22)
@@ -124,7 +130,11 @@ struct ItemListItem: View {
                         .cornerRadius(16)
                 } else {
                     Image(systemName: .folder)
-                        .onTapGesture { viewModel.stock() }
+                        .onTapGesture {
+                            Task {
+                                await viewModel.stock()
+                            }
+                        }
                         .frame(width: 32, height: 32)
                         .imageScale(.medium)
                         .border(Color("brand"), width: 1, cornerRadius: 22)

--- a/Qiita_SwiftUI/Presentation/Screen/Login/LoginView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Login/LoginView.swift
@@ -14,12 +14,12 @@ struct LoginView: View {
     @EnvironmentObject var authState: AuthState
     @State private var isPresented = false
 
-    @ObservedObject private var viewModel: LoginViewModel
+    @StateObject private var viewModel: LoginViewModel
 
     // MARK: - Initializer
 
     init(viewModel: LoginViewModel) {
-        self.viewModel = viewModel
+        self._viewModel = StateObject(wrappedValue: viewModel)
     }
 
     // MARK: - Body
@@ -27,9 +27,12 @@ struct LoginView: View {
     var body: some View {
         Button("Login") {
             isPresented = true
-            viewModel.login() {
-                authState.isSignedin = true
-                isPresented = false
+            // MainActorならこれ要らないのでは...?
+            Task {
+                await viewModel.login() {
+                    authState.isSignedin = true
+                    isPresented = false
+                }
             }
         }.sheet(isPresented: $isPresented, content: {
             SafariView(url: AppConstant.Auth.signinURL)

--- a/Qiita_SwiftUI/Presentation/Screen/Login/LoginView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Login/LoginView.swift
@@ -27,7 +27,6 @@ struct LoginView: View {
     var body: some View {
         Button("Login") {
             isPresented = true
-            // MainActorならこれ要らないのでは...?
             Task {
                 await viewModel.login() {
                     authState.isSignedin = true

--- a/Qiita_SwiftUI/Presentation/Screen/Login/LoginViewModel.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Login/LoginViewModel.swift
@@ -7,14 +7,13 @@
 
 import Foundation
 import SwiftUI
-import Combine
 
+@MainActor
 final class LoginViewModel: ObservableObject, Identifiable {
 
     // MARK: - Property
 
     private let authRepository: AuthRepository
-    private var cancellables = [AnyCancellable]()
 
     // MARK: - Initializer
 
@@ -24,19 +23,13 @@ final class LoginViewModel: ObservableObject, Identifiable {
 
     // MARK: - Public
 
-    func login(success: @escaping () -> Void) {
-        authRepository.signin()
-            .receive(on: DispatchQueue.main)
-            .sink(receiveCompletion: { completion in
-                switch completion {
-                case .finished:
-                    break
-                case .failure(let error):
-                    Logger.error(error)
-                }
-            }, receiveValue: { _ in
-                success()
-            }).store(in: &cancellables)
+    func login(success: @escaping () -> Void) async {
+        do {
+            _ = try await authRepository.signin()
+            success()
+        } catch {
+            Logger.error(error)
+        }
     }
 
     func handleDeepLink(url: URL) {

--- a/Qiita_SwiftUI/Presentation/Screen/Search/SearchView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Search/SearchView.swift
@@ -13,7 +13,7 @@ struct SearchView: View {
     // MARK: - Property
 
     @EnvironmentObject var repositoryContainer: RepositoryContainer
-    @ObservedObject private var viewModel: SearchViewModel
+    @StateObject private var viewModel: SearchViewModel
 
     @State private var isEditing: Bool = false
     @State private var searchText: String = ""
@@ -24,7 +24,7 @@ struct SearchView: View {
     // MARK: - Initializer
 
     init(viewModel: SearchViewModel) {
-        self.viewModel = viewModel
+        self._viewModel = StateObject(wrappedValue: viewModel)
     }
 
     // MARK: - Body
@@ -69,7 +69,9 @@ struct SearchView: View {
             }
             .onAppear {
                 if isInitialOnAppear {
-                    viewModel.fetchTags()
+                    Task {
+                        await viewModel.fetchTags()
+                    }
                     isInitialOnAppear = false
                 }
 

--- a/Qiita_SwiftUI/Presentation/Screen/Search/SearchViewModel.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Search/SearchViewModel.swift
@@ -6,8 +6,8 @@
 //
 
 import Foundation
-import Combine
 
+@MainActor
 final class SearchViewModel: ObservableObject {
 
     // MARK: - Property
@@ -15,7 +15,6 @@ final class SearchViewModel: ObservableObject {
     @Published var tags: [ItemTag] = []
 
     private let tagRepository: TagRepository
-    private var cancellables = [AnyCancellable]()
 
     // MARK: - Initializer
 
@@ -25,18 +24,11 @@ final class SearchViewModel: ObservableObject {
 
     // MARK: - Public
 
-    func fetchTags() {
-        tagRepository.getTags(page: 1, perPage: 30, sort: "count")
-            .receive(on: DispatchQueue.main)
-            .sink(receiveCompletion: { completion in
-                switch completion {
-                case .finished:
-                    break
-                case .failure(let error):
-                    Logger.error(error)
-                }
-            }, receiveValue: { tags in
-                self.tags = tags
-            }).store(in: &cancellables)
+    func fetchTags() async {
+        do {
+            tags = try await tagRepository.getTags(page: 1, perPage: 30, sort: "count")
+        } catch {
+            Logger.error(error)
+        }
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/SearchResult/Component/TagInformationView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/SearchResult/Component/TagInformationView.swift
@@ -13,16 +13,18 @@ struct TagInformationView: View {
 
     @EnvironmentObject var repositoryContainer: RepositoryContainer
 
-    @ObservedObject private var viewModel: TagInformationViewModel
+    @StateObject private var viewModel: TagInformationViewModel
     @State private var isInitialOnAppear = true
 
     // MARK: - Initializer
 
     init(viewModel: TagInformationViewModel) {
-        self.viewModel = viewModel
+        self._viewModel = StateObject(wrappedValue: viewModel)
 
         /// FIXME: ItemListItemと同様にonAppearでやると再描画されて状態が上書きされる
-        viewModel.checkIsFollowed()
+        Task {
+            await viewModel.checkIsFollowed()
+        }
     }
 
     // MARK: - Body
@@ -49,7 +51,11 @@ struct TagInformationView: View {
                     .foregroundColor(Color.white)
                     .background(Color("brand"))
                     .frame(width: 150, height: 30)
-                    .onTapGesture { viewModel.unfollow() }
+                    .onTapGesture {
+                        Task {
+                            await viewModel.unfollow()
+                        }
+                    }
             } else {
                 Text("フォローする")
                     .font(.system(size: 18, weight: .bold))
@@ -59,7 +65,11 @@ struct TagInformationView: View {
                     .foregroundColor(Color("brand"))
                     .background(Color.clear)
                     .frame(width: 150, height: 30)
-                    .onTapGesture { viewModel.follow() }
+                    .onTapGesture {
+                        Task {
+                            await viewModel.follow()
+                        }
+                    }
             }
         }
     }

--- a/Qiita_SwiftUI/Presentation/Screen/SearchResult/Component/TagInformationView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/SearchResult/Component/TagInformationView.swift
@@ -20,11 +20,6 @@ struct TagInformationView: View {
 
     init(viewModel: TagInformationViewModel) {
         self._viewModel = StateObject(wrappedValue: viewModel)
-
-        /// FIXME: ItemListItemと同様にonAppearでやると再描画されて状態が上書きされる
-        Task {
-            await viewModel.checkIsFollowed()
-        }
     }
 
     // MARK: - Body
@@ -70,6 +65,14 @@ struct TagInformationView: View {
                             await viewModel.follow()
                         }
                     }
+            }
+        }.onAppear {
+            if isInitialOnAppear {
+                Task {
+                    await viewModel.checkIsFollowed()
+                }
+                
+                isInitialOnAppear = false
             }
         }
     }

--- a/Qiita_SwiftUI/Presentation/Screen/SearchResult/SearchResultView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/SearchResult/SearchResultView.swift
@@ -43,15 +43,15 @@ struct SearchResultView: View {
                         .frame(width: reader.size.width - 32)
                 }
             })
-                .navigationTitle(navigationTitle)
-                .onAppear {
-                    if isInitialOnAppear {
-                        Task {
-                            await viewModel.fetchItems()
-                        }
-                        isInitialOnAppear = false
+            .navigationTitle(navigationTitle)
+            .onAppear {
+                if isInitialOnAppear {
+                    Task {
+                        await viewModel.fetchItems()
                     }
+                    isInitialOnAppear = false
                 }
+            }
         }
     }
 

--- a/Qiita_SwiftUI/Presentation/Screen/Setting/SettingView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Setting/SettingView.swift
@@ -16,13 +16,13 @@ struct SettingView: View {
     @Binding private var isPresenting: Bool
     @State private var showingAlert = false
 
-    @ObservedObject private var viewModel: SettingViewModel
+    @StateObject private var viewModel: SettingViewModel
 
     // MARK: - Initializer
 
     init(isPresenting: Binding<Bool>, viewModel: SettingViewModel) {
         self._isPresenting = isPresenting
-        self.viewModel = viewModel
+        self._viewModel = StateObject(wrappedValue: viewModel)
     }
 
     // MARK: - Body
@@ -50,7 +50,9 @@ struct SettingView: View {
                                   message: Text("本当によろしいですか?"),
                                   primaryButton: .cancel(Text("キャンセル")),
                                   secondaryButton: .destructive(Text("ログアウト")) {
-                                    viewModel.logout() {
+
+                                Task {
+                                    await viewModel.logout() {
                                         isPresenting = false
 
                                         // authStateが変わるとログイン画面に戻るが
@@ -60,7 +62,8 @@ struct SettingView: View {
                                             authState.isSignedin = false
                                         }
                                     }
-                                  })
+                                }
+                            })
                         }
                         Spacer()
                     }

--- a/Qiita_SwiftUI/Presentation/Screen/Setting/SettingViewModel.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Setting/SettingViewModel.swift
@@ -6,14 +6,13 @@
 //
 
 import Foundation
-import Combine
 
+@MainActor
 final class SettingViewModel: ObservableObject, Identifiable {
 
     // MARK: - Property
 
     private let authRepository: AuthRepository
-    private var cancellables = [AnyCancellable]()
 
     // MARK: - Initializer
 
@@ -23,19 +22,13 @@ final class SettingViewModel: ObservableObject, Identifiable {
 
     // MARK: - Public
 
-    func logout(completion: @escaping () -> Void) {
-        authRepository.signout()
-            .receive(on: DispatchQueue.main)
-            .sink(receiveCompletion: { completion in
-                switch completion {
-                case .finished:
-                    break
-                case .failure(let error):
-                    Logger.error(error)
-                }
-            }, receiveValue: { _ in
-                completion()
-            }).store(in: &cancellables)
+    func logout(completion: @escaping () -> Void) async {
+        do {
+            try await authRepository.signout()
+            completion()
+        } catch {
+            Logger.error(error)
+        }
     }
 }
 

--- a/Qiita_SwiftUI/Repository/AuthRepository.swift
+++ b/Qiita_SwiftUI/Repository/AuthRepository.swift
@@ -5,7 +5,6 @@
 //  Created by kntk on 2021/03/15.
 //
 
-import Combine
 import Foundation
 
 protocol AuthRepository {
@@ -17,11 +16,11 @@ protocol AuthRepository {
     func handleDeepLink(url: URL)
 
     /// ログイン中のユーザーを取得する
-    func getCurrentUser() -> AnyPublisher<User, Error>
+    func getCurrentUser() async throws -> User
 
     /// ログインする
-    func signin() -> AnyPublisher<AuthModel, Error>
+    func signin() async throws -> AuthModel
 
     /// ログアウトする
-    func signout() -> AnyPublisher<Void, Error>
+    func signout() async throws -> Void
 }

--- a/Qiita_SwiftUI/Repository/ItemRepository.swift
+++ b/Qiita_SwiftUI/Repository/ItemRepository.swift
@@ -5,8 +5,6 @@
 //  Created by kntk on 2021/03/15.
 //
 
-import Combine
-
 enum SearchType {
     case word(String)
     case tag(ItemTag)
@@ -15,14 +13,14 @@ enum SearchType {
 protocol ItemRepository {
 
     /// 新着記事一覧を取得する
-    func getItems(page: Int) -> AnyPublisher<[Item], Error>
+    func getItems(page: Int) async throws -> [Item]
 
     /// 新着記事一覧から検索する
-    func getItems(with type: SearchType?, page: Int) -> AnyPublisher<[Item], Error>
+    func getItems(with type: SearchType?, page: Int) async throws -> [Item]
 
     /// 特定のユーザーの記事一覧を取得する
-    func getItems(by user: User, page: Int, perPage: Int) -> AnyPublisher<[Item], Error>
+    func getItems(by user: User, page: Int, perPage: Int) async throws -> [Item]
 
     /// 自分の記事一覧を取得する
-    func getAuthenticatedUserItems(page: Int, perPage: Int) -> AnyPublisher<[Item], Error>
+    func getAuthenticatedUserItems(page: Int, perPage: Int) async throws -> [Item]
 }

--- a/Qiita_SwiftUI/Repository/LikeRepository.swift
+++ b/Qiita_SwiftUI/Repository/LikeRepository.swift
@@ -5,16 +5,14 @@
 //  Created by kntk on 2021/03/15.
 //
 
-import Combine
-
 protocol LikeRepository {
 
     /// 記事をいいねする
-    func like(id: Item.ID) -> AnyPublisher<VoidModel, Error>
+    func like(id: Item.ID) async throws -> VoidModel
 
     /// 記事のいいねを解除する
-    func unlike(id: Item.ID) -> AnyPublisher<VoidModel, Error>
+    func unlike(id: Item.ID) async throws -> VoidModel
 
     /// 記事をいいねしているかどうか確認する
-    func checkIsLiked(id: Item.ID) -> AnyPublisher<VoidModel, Error>
+    func checkIsLiked(id: Item.ID) async throws -> VoidModel
 }

--- a/Qiita_SwiftUI/Repository/StockRepository.swift
+++ b/Qiita_SwiftUI/Repository/StockRepository.swift
@@ -5,19 +5,17 @@
 //  Created by kntk on 2021/03/15.
 //
 
-import Combine
-
 protocol StockRepository {
 
     /// ストック記事一覧を取得する
-    func getStocks(page: Int, perPage: Int) -> AnyPublisher<[Item], Error>
+    func getStocks(page: Int, perPage: Int) async throws -> [Item]
 
     /// 記事をストックする
-    func stock(id: Item.ID) -> AnyPublisher<VoidModel, Error>
+    func stock(id: Item.ID) async throws -> VoidModel
 
     /// 記事のストックを解除する
-    func unstock(id: Item.ID) -> AnyPublisher<VoidModel, Error>
+    func unstock(id: Item.ID) async throws -> VoidModel
 
     /// 記事をストックしているか確認する
-    func checkIsStocked(id: Item.ID) -> AnyPublisher<VoidModel, Error>
+    func checkIsStocked(id: Item.ID) async throws -> VoidModel
 }

--- a/Qiita_SwiftUI/Repository/TagRepository.swift
+++ b/Qiita_SwiftUI/Repository/TagRepository.swift
@@ -5,19 +5,17 @@
 //  Created by kntk on 2021/03/15.
 //
 
-import Combine
-
 protocol TagRepository {
 
     /// タグ一覧を取得する
-    func getTags(page: Int, perPage: Int, sort: String) -> AnyPublisher<[ItemTag], Error>
+    func getTags(page: Int, perPage: Int, sort: String) async throws -> [ItemTag]
 
     /// タグをフォローする
-    func follow(id: ItemTag.ID) -> AnyPublisher<VoidModel, Error>
+    func follow(id: ItemTag.ID) async throws -> VoidModel
 
     /// タグのフォローを外す
-    func unfollow(id: ItemTag.ID) -> AnyPublisher<VoidModel, Error>
+    func unfollow(id: ItemTag.ID) async throws -> VoidModel
 
     /// タグをフォローしているか確かめる
-    func checkIsFollowed(id: ItemTag.ID) -> AnyPublisher<VoidModel, Error>
+    func checkIsFollowed(id: ItemTag.ID) async throws -> VoidModel
 }

--- a/Qiita_SwiftUI/Repository/UserRepository.swift
+++ b/Qiita_SwiftUI/Repository/UserRepository.swift
@@ -5,10 +5,8 @@
 //  Created by kntk on 2021/03/15.
 //
 
-import Combine
-
 protocol UserRepository {
 
     /// 特定のユーザーを取得する
-    func getUser(id: User.ID) -> AnyPublisher<User, Error>
+    func getUser(id: User.ID) async throws -> User
 }

--- a/Qiita_SwiftUI/Service/AuthService.swift
+++ b/Qiita_SwiftUI/Service/AuthService.swift
@@ -18,15 +18,15 @@ final class AuthService: AuthRepository {
         Auth.shared.handleDeepLink(url: url)
     }
 
-    func getCurrentUser() -> AnyPublisher<User, Error> {
-        return Auth.shared.currentUser
+    func getCurrentUser() async throws -> User {
+        return try await Auth.shared.getCurrentUser()
     }
 
-    func signin() -> AnyPublisher<AuthModel, Error> {
-        return Auth.shared.signin()
+    func signin() async throws -> AuthModel {
+        return try await Auth.shared.signin()
     }
 
-    func signout() -> AnyPublisher<Void, Error> {
-        return Auth.shared.signout()
+    func signout() async throws -> Void {
+        return try await Auth.shared.signout()
     }
 }

--- a/Qiita_SwiftUI/Service/AuthService.swift
+++ b/Qiita_SwiftUI/Service/AuthService.swift
@@ -5,7 +5,6 @@
 //  Created by kntk on 2021/03/15.
 //
 
-import Combine
 import Foundation
 
 final class AuthService: AuthRepository {

--- a/Qiita_SwiftUI/Service/ItemService.swift
+++ b/Qiita_SwiftUI/Service/ItemService.swift
@@ -5,7 +5,6 @@
 //  Created by kntk on 2021/03/15.
 //
 
-import Combine
 
 final class ItemService: ItemRepository {
 

--- a/Qiita_SwiftUI/Service/ItemService.swift
+++ b/Qiita_SwiftUI/Service/ItemService.swift
@@ -9,30 +9,28 @@ import Combine
 
 final class ItemService: ItemRepository {
 
-    func getItems(page: Int) -> AnyPublisher<[Item], Error> {
-        return API.shared.call(ItemTarget.getItems(page: page)).eraseToAnyPublisher()
+    func getItems(page: Int) async throws -> [Item] {
+        return try await API.shared.call(ItemTarget.getItems(page: page))
     }
 
-    // FIXME: Optionalやめたい
-    func getItems(with type: SearchType?, page: Int) -> AnyPublisher<[Item], Error> {
+    func getItems(with type: SearchType?, page: Int) async throws -> [Item] {
         switch type {
         case .word(let word):
-            return API.shared.call(ItemTarget.getItemsByQuery(page: page, query: word)).eraseToAnyPublisher()
-            
+            return try await API.shared.call(ItemTarget.getItemsByQuery(page: page, query: word))
+
         case .tag(let tag):
-            return API.shared.call(TagTarget.getItems(page: page, id: tag.id)).eraseToAnyPublisher()
+            return try await API.shared.call(TagTarget.getItems(page: page, id: tag.id))
 
         case .none:
-            return getItems(page: page)
+            return try await getItems(page: page)
         }
     }
 
-    // TODO: UserServiceに置く？
-    func getItems(by user: User, page: Int, perPage: Int) -> AnyPublisher<[Item], Error> {
-        return API.shared.call(UserTarget.getItems(page: page, perPage: perPage, id: user.id)).eraseToAnyPublisher()
+    func getItems(by user: User, page: Int, perPage: Int) async throws -> [Item] {
+        return try await API.shared.call(UserTarget.getItems(page: page, perPage: perPage, id: user.id))
     }
 
-    func getAuthenticatedUserItems(page: Int, perPage: Int) -> AnyPublisher<[Item], Error> {
-        return API.shared.call(UserTarget.getAuthenticatedUserItems(page: page, perPage: perPage)).eraseToAnyPublisher()
+    func getAuthenticatedUserItems(page: Int, perPage: Int) async throws -> [Item] {
+        return try await API.shared.call(UserTarget.getAuthenticatedUserItems(page: page, perPage: perPage))
     }
 }

--- a/Qiita_SwiftUI/Service/LikeService.swift
+++ b/Qiita_SwiftUI/Service/LikeService.swift
@@ -5,8 +5,6 @@
 //  Created by kntk on 2021/03/15.
 //
 
-import Combine
-
 final class LikeService: LikeRepository {
 
     func like(id: Item.ID) async throws -> VoidModel {

--- a/Qiita_SwiftUI/Service/LikeService.swift
+++ b/Qiita_SwiftUI/Service/LikeService.swift
@@ -9,15 +9,15 @@ import Combine
 
 final class LikeService: LikeRepository {
 
-    func like(id: Item.ID) -> AnyPublisher<VoidModel, Error> {
-        return API.shared.call(ItemTarget.like(id: id)).eraseToAnyPublisher()
+    func like(id: Item.ID) async throws -> VoidModel {
+        return try await API.shared.call(ItemTarget.like(id: id))
     }
 
-    func unlike(id: Item.ID) -> AnyPublisher<VoidModel, Error> {
-        return API.shared.call(ItemTarget.unlike(id: id)).eraseToAnyPublisher()
+    func unlike(id: Item.ID) async throws -> VoidModel {
+        return try await API.shared.call(ItemTarget.unlike(id: id))
     }
 
-    func checkIsLiked(id: Item.ID) -> AnyPublisher<VoidModel, Error> {
-        return API.shared.call(ItemTarget.checkIsLiked(id: id)).eraseToAnyPublisher()
+    func checkIsLiked(id: Item.ID) async throws -> VoidModel {
+        return try await API.shared.call(ItemTarget.checkIsLiked(id: id))
     }
 }

--- a/Qiita_SwiftUI/Service/StockService.swift
+++ b/Qiita_SwiftUI/Service/StockService.swift
@@ -5,8 +5,6 @@
 //  Created by kntk on 2021/03/15.
 //
 
-import Combine
-
 final class StockService: StockRepository {
 
     func getStocks(page: Int, perPage: Int) async throws -> [Item] {

--- a/Qiita_SwiftUI/Service/StockService.swift
+++ b/Qiita_SwiftUI/Service/StockService.swift
@@ -9,22 +9,20 @@ import Combine
 
 final class StockService: StockRepository {
 
-    func getStocks(page: Int, perPage: Int) -> AnyPublisher<[Item], Error> {
-        return Auth.shared.currentUser
-            .flatMap { user in
-                API.shared.call(UserTarget.getStocks(page: page, perPage: perPage, id: user.id))
-            }.eraseToAnyPublisher()
+    func getStocks(page: Int, perPage: Int) async throws -> [Item] {
+        let user = try await Auth.shared.getCurrentUser()
+        return try await API.shared.call(UserTarget.getStocks(page: page, perPage: perPage, id: user.id))
     }
 
-    func stock(id: Item.ID) -> AnyPublisher<VoidModel, Error> {
-        return API.shared.call(ItemTarget.stock(id: id)).eraseToAnyPublisher()
+    func stock(id: Item.ID) async throws -> VoidModel {
+        return try await API.shared.call(ItemTarget.stock(id: id))
     }
 
-    func unstock(id: Item.ID) -> AnyPublisher<VoidModel, Error> {
-        return API.shared.call(ItemTarget.unstock(id: id)).eraseToAnyPublisher()
+    func unstock(id: Item.ID) async throws -> VoidModel {
+        return try await API.shared.call(ItemTarget.unstock(id: id))
     }
 
-    func checkIsStocked(id: Item.ID) -> AnyPublisher<VoidModel, Error> {
-        return API.shared.call(ItemTarget.checkIsStocked(id: id)).eraseToAnyPublisher()
+    func checkIsStocked(id: Item.ID) async throws -> VoidModel {
+        return try await API.shared.call(ItemTarget.checkIsStocked(id: id))
     }
 }

--- a/Qiita_SwiftUI/Service/Stub/AuthStubService.swift
+++ b/Qiita_SwiftUI/Service/Stub/AuthStubService.swift
@@ -5,7 +5,6 @@
 //  Created by kntk on 2021/03/15.
 //
 
-import Combine
 import Foundation
 
 final class AuthStubService: AuthRepository {
@@ -20,15 +19,15 @@ final class AuthStubService: AuthRepository {
         
     }
 
-    func getCurrentUser() -> AnyPublisher<User, Error> {
-        return Future { $0(.success(self.user)) }.eraseToAnyPublisher()
+    func getCurrentUser() async throws -> User {
+        return await withCheckedContinuation { $0.resume(returning: self.user) }
     }
 
-    func signin() -> AnyPublisher<AuthModel, Error> {
-        return Future { $0(.success(self.authModel)) }.eraseToAnyPublisher()
+    func signin() async throws -> AuthModel {
+        return await withCheckedContinuation { $0.resume(returning: self.authModel) }
     }
 
-    func signout() -> AnyPublisher<Void, Error> {
-        return Future { $0(.success(())) }.eraseToAnyPublisher()
+    func signout() async throws -> Void {
+        return await withCheckedContinuation { $0.resume(returning: ()) }
     }
 }

--- a/Qiita_SwiftUI/Service/Stub/ItemStubService.swift
+++ b/Qiita_SwiftUI/Service/Stub/ItemStubService.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import Combine
 
 final class ItemStubService: ItemRepository {
 
@@ -16,30 +15,20 @@ final class ItemStubService: ItemRepository {
 
     // MARK: - Public
 
-    func getItems(page: Int) -> AnyPublisher<[Item], Error> {
-        return Future { $0(.success(Self.items)) }.eraseToAnyPublisher()
+    func getItems(page: Int) async throws -> [Item] {
+        return await withCheckedContinuation { $0.resume(returning: Self.items) }
     }
 
-    // FIXME: Optionalやめたい
-    func getItems(with type: SearchType?, page: Int) -> AnyPublisher<[Item], Error> {
-        switch type {
-        case .word:
-            return Future { $0(.success(Self.items)) }.eraseToAnyPublisher()
-
-        case .tag:
-            return Future { $0(.success(Self.items)) }.eraseToAnyPublisher()
-
-        case .none:
-            return getItems(page: page)
-        }
+    func getItems(with type: SearchType?, page: Int) async throws -> [Item] {
+        return await withCheckedContinuation { $0.resume(returning: Self.items) }
     }
 
     // TODO: UserServiceに置く？
-    func getItems(by user: User, page: Int, perPage: Int) -> AnyPublisher<[Item], Error> {
-        return Future { $0(.success(Self.items)) }.eraseToAnyPublisher()
+    func getItems(by user: User, page: Int, perPage: Int) async throws -> [Item] {
+        return await withCheckedContinuation { $0.resume(returning: Self.items) }
     }
 
-    func getAuthenticatedUserItems(page: Int, perPage: Int) -> AnyPublisher<[Item], Error> {
-        return Future { $0(.success(Self.items)) }.eraseToAnyPublisher()
+    func getAuthenticatedUserItems(page: Int, perPage: Int) async throws -> [Item] {
+        return await withCheckedContinuation { $0.resume(returning: Self.items) }
     }
 }

--- a/Qiita_SwiftUI/Service/Stub/LikeStubService.swift
+++ b/Qiita_SwiftUI/Service/Stub/LikeStubService.swift
@@ -6,19 +6,18 @@
 //
 
 import Foundation
-import Combine
 
 final class LikeStubService: LikeRepository {
 
-    func like(id: Item.ID) -> AnyPublisher<VoidModel, Error> {
-        return Future { $0(.success(VoidModel())) }.eraseToAnyPublisher()
+    func like(id: Item.ID) async throws -> VoidModel {
+        return await withCheckedContinuation { $0.resume(returning: VoidModel()) }
     }
 
-    func unlike(id: Item.ID) -> AnyPublisher<VoidModel, Error> {
-        return Future { $0(.success(VoidModel())) }.eraseToAnyPublisher()
+    func unlike(id: Item.ID) async throws -> VoidModel {
+        return await withCheckedContinuation { $0.resume(returning: VoidModel()) }
     }
 
-    func checkIsLiked(id: Item.ID) -> AnyPublisher<VoidModel, Error> {
-        return Future { $0(.success(VoidModel())) }.eraseToAnyPublisher()
+    func checkIsLiked(id: Item.ID) async throws -> VoidModel {
+        return await withCheckedContinuation { $0.resume(returning: VoidModel()) }
     }
 }

--- a/Qiita_SwiftUI/Service/Stub/StockStubService.swift
+++ b/Qiita_SwiftUI/Service/Stub/StockStubService.swift
@@ -5,23 +5,22 @@
 //  Created by kntk on 2021/05/15.
 //
 
-import Combine
 
 final class StockStubService: StockRepository {
 
-    func getStocks(page: Int, perPage: Int) -> AnyPublisher<[Item], Error> {
-        return Future { $0(.success(ItemStubService.items)) }.eraseToAnyPublisher()
+    func getStocks(page: Int, perPage: Int) async throws -> [Item] {
+        return await withCheckedContinuation { $0.resume(returning: ItemStubService.items) }
     }
 
-    func stock(id: Item.ID) -> AnyPublisher<VoidModel, Error> {
-        return Future { $0(.success(VoidModel())) }.eraseToAnyPublisher()
+    func stock(id: Item.ID) async throws -> VoidModel {
+        return await withCheckedContinuation { $0.resume(returning: VoidModel()) }
     }
 
-    func unstock(id: Item.ID) -> AnyPublisher<VoidModel, Error> {
-        return Future { $0(.success(VoidModel())) }.eraseToAnyPublisher()
+    func unstock(id: Item.ID) async throws -> VoidModel {
+        return await withCheckedContinuation { $0.resume(returning: VoidModel()) }
     }
 
-    func checkIsStocked(id: Item.ID) -> AnyPublisher<VoidModel, Error> {
-        return Future { $0(.success(VoidModel())) }.eraseToAnyPublisher()
+    func checkIsStocked(id: Item.ID) async throws -> VoidModel {
+        return await withCheckedContinuation { $0.resume(returning: VoidModel()) }
     }
 }

--- a/Qiita_SwiftUI/Service/Stub/TagStubService.swift
+++ b/Qiita_SwiftUI/Service/Stub/TagStubService.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import Combine
 
 final class TagStubService: TagRepository {
 
@@ -20,19 +19,19 @@ final class TagStubService: TagRepository {
         ItemTag(iconUrl: URL(string: "https://avatars2.githubusercontent.com/u/44288050?v=4")!, followersCount: 10, id: "Ruby", itemsCount: 10)
     ]
 
-    func getTags(page: Int, perPage: Int, sort: String) -> AnyPublisher<[ItemTag], Error> {
-        return Future { $0(.success(self.tags)) }.eraseToAnyPublisher()
+    func getTags(page: Int, perPage: Int, sort: String) async throws -> [ItemTag] {
+        return await withCheckedContinuation { $0.resume(returning: self.tags) }
     }
 
-    func follow(id: ItemTag.ID) -> AnyPublisher<VoidModel, Error> {
-        return Future { $0(.success(VoidModel())) }.eraseToAnyPublisher()
+    func follow(id: ItemTag.ID) async throws -> VoidModel {
+        return await withCheckedContinuation { $0.resume(returning: VoidModel()) }
     }
 
-    func unfollow(id: ItemTag.ID) -> AnyPublisher<VoidModel, Error> {
-        return Future { $0(.success(VoidModel())) }.eraseToAnyPublisher()
+    func unfollow(id: ItemTag.ID) async throws -> VoidModel {
+        return await withCheckedContinuation { $0.resume(returning: VoidModel()) }
     }
 
-    func checkIsFollowed(id: ItemTag.ID) -> AnyPublisher<VoidModel, Error> {
-        return Future { $0(.success(VoidModel())) }.eraseToAnyPublisher()
+    func checkIsFollowed(id: ItemTag.ID) async throws -> VoidModel {
+        return await withCheckedContinuation { $0.resume(returning: VoidModel()) }
     }
 }

--- a/Qiita_SwiftUI/Service/Stub/UserStubService.swift
+++ b/Qiita_SwiftUI/Service/Stub/UserStubService.swift
@@ -6,13 +6,12 @@
 //
 
 import Foundation
-import Combine
 
 final class UserStubService: UserRepository {
 
     let user = User(id: "kntkymt", name: "kntkymt", description: "iOSエンジニアです", profileImageUrl: URL(string: "https://avatars2.githubusercontent.com/u/44288050?v=4")!, itemsCount: 10, followeesCount: 20, followersCount: 30)
 
-    func getUser(id: User.ID) -> AnyPublisher<User, Error> {
-        return Future { $0(.success(self.user)) }.eraseToAnyPublisher()
+    func getUser(id: User.ID) async throws -> User {
+        return await withCheckedContinuation { $0.resume(returning: self.user) }
     }
 }

--- a/Qiita_SwiftUI/Service/TagService.swift
+++ b/Qiita_SwiftUI/Service/TagService.swift
@@ -9,19 +9,19 @@ import Combine
 
 final class TagService: TagRepository {
 
-    func getTags(page: Int, perPage: Int, sort: String) -> AnyPublisher<[ItemTag], Error> {
-        return API.shared.call(TagTarget.getTags(page: page, perPage: perPage, sort: sort)).eraseToAnyPublisher()
+    func getTags(page: Int, perPage: Int, sort: String) async throws -> [ItemTag] {
+        return try await API.shared.call(TagTarget.getTags(page: page, perPage: perPage, sort: sort))
     }
 
-    func follow(id: ItemTag.ID) -> AnyPublisher<VoidModel, Error> {
-        return API.shared.call(TagTarget.follow(id: id)).eraseToAnyPublisher()
+    func follow(id: ItemTag.ID) async throws -> VoidModel {
+        return try await API.shared.call(TagTarget.follow(id: id))
     }
 
-    func unfollow(id: ItemTag.ID) -> AnyPublisher<VoidModel, Error> {
-        return API.shared.call(TagTarget.unfollow(id: id)).eraseToAnyPublisher()
+    func unfollow(id: ItemTag.ID) async throws -> VoidModel {
+        return try await API.shared.call(TagTarget.unfollow(id: id))
     }
 
-    func checkIsFollowed(id: ItemTag.ID) -> AnyPublisher<VoidModel, Error> {
-        return API.shared.call(TagTarget.checkIsFollowed(id: id)).eraseToAnyPublisher()
+    func checkIsFollowed(id: ItemTag.ID) async throws -> VoidModel {
+        return try await API.shared.call(TagTarget.checkIsFollowed(id: id))
     }
 }

--- a/Qiita_SwiftUI/Service/TagService.swift
+++ b/Qiita_SwiftUI/Service/TagService.swift
@@ -5,8 +5,6 @@
 //  Created by kntk on 2021/03/15.
 //
 
-import Combine
-
 final class TagService: TagRepository {
 
     func getTags(page: Int, perPage: Int, sort: String) async throws -> [ItemTag] {

--- a/Qiita_SwiftUI/Service/UserService.swift
+++ b/Qiita_SwiftUI/Service/UserService.swift
@@ -9,7 +9,7 @@ import Combine
 
 final class UserService: UserRepository {
 
-    func getUser(id: User.ID) -> AnyPublisher<User, Error> {
-        return API.shared.call(UserTarget.get(id: id)).eraseToAnyPublisher()
+    func getUser(id: User.ID) async throws -> User {
+        return try await API.shared.call(UserTarget.get(id: id))
     }
 }

--- a/Qiita_SwiftUI/Service/UserService.swift
+++ b/Qiita_SwiftUI/Service/UserService.swift
@@ -5,8 +5,6 @@
 //  Created by kntk on 2021/03/15.
 //
 
-import Combine
-
 final class UserService: UserRepository {
 
     func getUser(id: User.ID) async throws -> User {


### PR DESCRIPTION
## 概要
- 全部Combineからasync awaitへ

## 実装
- APIを全部`async await`に
    - Repositoryでは`async throws`、ViewModelでエラーハンドリングして`async`にする
    - ViewModel側で`Task { }`するのは多分違う
- ViewModelは`StateObject`に
    - `ObservedObject`はViewが再生成されると死ぬが、`StateObject`は死なない
    - `StateObject`にしたことによってストック確認を`onAppear`でやっても良くなった
- ViewModelで`MainActor`を使う
    - Viewからの`Task { }`が必ずメインスレッドでのアクセスとなる
    - `DIsplatchQueue.main.async`を気にしなくていい
- `.onAppear`から`.task`にする?
    - `.task`の挙動は`.onAppear`と同じっぽい
    - まあやってもいいが、 `isInitialTask` が必要になるのでとりあえず`onAppear`でT`ask { }`ってやっとけばいいか