### PR TITLE
SearchBarをSwiftUI純正のものにする

### DIFF
--- a/Qiita_SwiftUI/Presentation/Screen/Search/SearchView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Search/SearchView.swift
@@ -62,11 +62,8 @@ struct SearchView: View {
                 }
             }
             .navigationBarTitle("Search", displayMode: .inline)
-            .navigationSearchBar {
-                SearchBar("キーワード検索", text: $searchText, isEditing: $isEditing, onCommit: { isPush.toggle() })
-                    .showsCancelButton(isEditing)
-
-            }
+            .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always), prompt: Text("キーワード検索"))
+            .onSubmit(of: .search) { isPush.toggle() }
             .onAppear {
                 if isInitialOnAppear {
                     Task {


### PR DESCRIPTION
## 概要
- SwiftUIXのSearchBarを使っていたがiOS15で純正のものが出たので利用する

## 実装
- 仕様は同じ、挙動は安定してgood
- SwiftUIXのSearchBarはバグかった