### PR TITLE
FetchImageをAsyncImageにする

### DIFF
--- a/Qiita_SwiftUI.xcodeproj/project.pbxproj
+++ b/Qiita_SwiftUI.xcodeproj/project.pbxproj
@@ -70,7 +70,6 @@
 		E2729DE1264EC601009473D0 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DE0264EC601009473D0 /* HomeView.swift */; };
 		E2729DE3264ECA96009473D0 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DE2264ECA96009473D0 /* HomeViewModel.swift */; };
 		E2729DE6264ECDA7009473D0 /* ItemListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DE5264ECDA7009473D0 /* ItemListView.swift */; };
-		E2729DE9264F0C82009473D0 /* FetchImage in Frameworks */ = {isa = PBXBuildFile; productRef = E2729DE8264F0C82009473D0 /* FetchImage */; };
 		E2729DEB264F0D43009473D0 /* ImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DEA264F0D43009473D0 /* ImageView.swift */; };
 		E2729DEE264F15C4009473D0 /* ItemDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DED264F15C4009473D0 /* ItemDetailView.swift */; };
 		E2729DF0264F18F0009473D0 /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2729DEF264F18F0009473D0 /* WebView.swift */; };
@@ -207,7 +206,6 @@
 				E20DD36425FF460500735B0A /* Moya in Frameworks */,
 				E20DD38325FF483200735B0A /* SwiftyBeaver in Frameworks */,
 				E2BB277C2656B92100148F45 /* SwiftUIX in Frameworks */,
-				E2729DE9264F0C82009473D0 /* FetchImage in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -602,7 +600,6 @@
 				E20DD36325FF460500735B0A /* Moya */,
 				E20DD37C25FF47E600735B0A /* KeychainAccess */,
 				E20DD38225FF483200735B0A /* SwiftyBeaver */,
-				E2729DE8264F0C82009473D0 /* FetchImage */,
 				E2BB277B2656B92100148F45 /* SwiftUIX */,
 				E25E9AC526F6437C0090A0E3 /* Introspect */,
 			);
@@ -681,7 +678,6 @@
 				E20DD36225FF460500735B0A /* XCRemoteSwiftPackageReference "Moya" */,
 				E20DD37B25FF47E600735B0A /* XCRemoteSwiftPackageReference "KeychainAccess" */,
 				E20DD38125FF483200735B0A /* XCRemoteSwiftPackageReference "SwiftyBeaver" */,
-				E2729DE7264F0C82009473D0 /* XCRemoteSwiftPackageReference "FetchImage" */,
 				E2BB277A2656B92100148F45 /* XCRemoteSwiftPackageReference "SwiftUIX" */,
 				E25E9AC426F6437C0090A0E3 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */,
 			);
@@ -1152,14 +1148,6 @@
 				minimumVersion = 0.1.3;
 			};
 		};
-		E2729DE7264F0C82009473D0 /* XCRemoteSwiftPackageReference "FetchImage" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/kean/FetchImage.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.4.0;
-			};
-		};
 		E2BB277A2656B92100148F45 /* XCRemoteSwiftPackageReference "SwiftUIX" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SwiftUIX/SwiftUIX.git";
@@ -1190,11 +1178,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = E25E9AC426F6437C0090A0E3 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */;
 			productName = Introspect;
-		};
-		E2729DE8264F0C82009473D0 /* FetchImage */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = E2729DE7264F0C82009473D0 /* XCRemoteSwiftPackageReference "FetchImage" */;
-			productName = FetchImage;
 		};
 		E2BB277B2656B92100148F45 /* SwiftUIX */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Qiita_SwiftUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Qiita_SwiftUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -11,15 +11,6 @@
         }
       },
       {
-        "package": "FetchImage",
-        "repositoryURL": "https://github.com/kean/FetchImage.git",
-        "state": {
-          "branch": null,
-          "revision": "cac844a0dea908c6e068fc8c6a0f949179c7f876",
-          "version": "0.4.0"
-        }
-      },
-      {
         "package": "KeychainAccess",
         "repositoryURL": "https://github.com/kishikawakatsumi/KeychainAccess.git",
         "state": {
@@ -53,15 +44,6 @@
           "branch": null,
           "revision": "7a46a5fc86cb917f69e3daf79fcb045283d8f008",
           "version": "8.1.2"
-        }
-      },
-      {
-        "package": "Nuke",
-        "repositoryURL": "https://github.com/kean/Nuke.git",
-        "state": {
-          "branch": null,
-          "revision": "8e0f42d1d9f30d816f3c565aa6193d9363325157",
-          "version": "9.6.0"
         }
       },
       {

--- a/Qiita_SwiftUI/Presentation/Common/ImageView.swift
+++ b/Qiita_SwiftUI/Presentation/Common/ImageView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import FetchImage
 
 struct ImageView: View {
 
@@ -14,20 +13,19 @@ struct ImageView: View {
 
     var url: URL
 
-    @StateObject private var image = FetchImage()
-
     // MARK: - Public
 
     var body: some View {
         ZStack {
-            Rectangle().fill(Color.systemBackground)
-            image.view?
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .clipped()
+            AsyncImage(url: url, content: { image in
+                Rectangle().fill(Color.systemBackground)
+                image
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .clipped()
+            }, placeholder: {
+                Rectangle().fill(Color.systemGray)
+            })
         }
-        .onAppear { image.load(url) }
-        .onChange(of: url) { image.load($0) }
-        .onDisappear(perform: image.reset)
     }
 }


### PR DESCRIPTION
## 概要
- URLからの画像取得に`FetchImage`というライブラリを使っていたが、`AsyncImage`という純正が出たのでそちらに変える

## 実装
- `ImageView`の内部実装をAsyncImageに変える
- FetchImageを削除