### PR TITLE
FooterLoadingのインターフェースをrefreshableを参考に変える

### DIFF
--- a/Qiita_SwiftUI/Presentation/Common/FooterLoadingView.swift
+++ b/Qiita_SwiftUI/Presentation/Common/FooterLoadingView.swift
@@ -49,11 +49,12 @@ private struct FooterLoadingView: UIViewRepresentable {
                 let threshold = max(0.0, tableView.contentSize.height - visibleHeight)
 
                 if y > threshold {
-                    indicatorView.startAnimating()
-                    Task {
+                    Task(priority: .userInitiated) {
+                        indicatorView.startAnimating()
                         await action()
+                        await Task.sleep(1_000_000_000)
+                        indicatorView.stopAnimating()
                     }
-                    indicatorView.stopAnimating()
                 }
             })
         }

--- a/Qiita_SwiftUI/Presentation/Common/FooterLoadingView.swift
+++ b/Qiita_SwiftUI/Presentation/Common/FooterLoadingView.swift
@@ -14,7 +14,7 @@ private struct FooterLoadingView: UIViewRepresentable {
 
     @State private var observer: NSKeyValueObservation?
 
-    let onReachBottom: () -> Void
+    let action: () async -> Void
 
     private let indicatorView: UIActivityIndicatorView = {
         let indicatorView = UIActivityIndicatorView()
@@ -50,8 +50,9 @@ private struct FooterLoadingView: UIViewRepresentable {
 
                 if y > threshold {
                     indicatorView.startAnimating()
-                    onReachBottom()
-                } else {
+                    Task {
+                        await action()
+                    }
                     indicatorView.stopAnimating()
                 }
             })
@@ -77,8 +78,8 @@ private struct FooterLoadingView: UIViewRepresentable {
 }
 
 extension View {
-    public func footerLoading(onReachBottom: @escaping () -> Void) -> some View {
-        return overlay(FooterLoadingView(onReachBottom: onReachBottom)
+    public func moreLoadable(action: @escaping () async -> Void) -> some View {
+        return overlay(FooterLoadingView(action: action)
                         .frame(width: 0, height: 0))
     }
 }

--- a/Qiita_SwiftUI/Presentation/Screen/Home/HomeView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Home/HomeView.swift
@@ -31,9 +31,7 @@ struct HomeView: View {
             ItemListView(items: viewModel.items, onItemStockChangedHandler: nil, onRefresh: {
                 await viewModel.fetchItems()
             }, onPaging: {
-                Task {
-                    await  viewModel.fetchMoreItems()
-                }
+                await  viewModel.fetchMoreItems()
             }).navigationBarTitle("Home", displayMode: .inline)
         }.onAppear {
             if isInitialOnAppear {

--- a/Qiita_SwiftUI/Presentation/Screen/ItemList/ItemListView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/ItemList/ItemListView.swift
@@ -18,13 +18,13 @@ struct ItemListView<HeaderView: View>: View {
     private let onItemStockChangedHandler: ((Item, Bool) -> Void)?
 
     private let onRefresh: () async -> Void
-    private let onPaging: () -> Void
+    private let onPaging: () async -> Void
 
     private var headerView: HeaderView
 
     // MARK: - Initializer
 
-    init(items: [Item], onItemStockChangedHandler: ((Item, Bool) -> Void)? = nil, onRefresh: @escaping () async -> Void, onPaging: @escaping () -> Void, @ViewBuilder header: () -> HeaderView) {
+    init(items: [Item], onItemStockChangedHandler: ((Item, Bool) -> Void)? = nil, onRefresh: @escaping () async -> Void, onPaging: @escaping () async -> Void, @ViewBuilder header: () -> HeaderView) {
         self.items = items
         self.onItemStockChangedHandler = onItemStockChangedHandler
         self.onRefresh = onRefresh
@@ -33,7 +33,7 @@ struct ItemListView<HeaderView: View>: View {
     }
 
     // headerを使わない場合
-    init(items: [Item], onItemStockChangedHandler: ((Item, Bool) -> Void)? = nil, onRefresh: @escaping () async -> Void, onPaging: @escaping () -> Void) where HeaderView == EmptyView {
+    init(items: [Item], onItemStockChangedHandler: ((Item, Bool) -> Void)? = nil, onRefresh: @escaping () async -> Void, onPaging: @escaping () async -> Void) where HeaderView == EmptyView {
         self.items = items
         self.onItemStockChangedHandler = onItemStockChangedHandler
         self.onRefresh = onRefresh
@@ -57,7 +57,7 @@ struct ItemListView<HeaderView: View>: View {
         }
         .listStyle(PlainListStyle())
         .refreshable { await onRefresh() }
-        .footerLoading { onPaging() }
+        .moreLoadable { await onPaging() }
     }
 }
 

--- a/Qiita_SwiftUI/Presentation/Screen/Profile/ProfileView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Profile/ProfileView.swift
@@ -35,9 +35,7 @@ struct ProfileView: View {
                         ItemListView(items: viewModel.items, onItemStockChangedHandler: nil, onRefresh: {
                             await viewModel.fetchItems()
                         }, onPaging: {
-                            Task {
-                                await viewModel.fetchMoreItems()
-                            }
+                            await viewModel.fetchMoreItems()
                         })
                     }
                 } else {

--- a/Qiita_SwiftUI/Presentation/Screen/Stock/StockView.swift
+++ b/Qiita_SwiftUI/Presentation/Screen/Stock/StockView.swift
@@ -30,9 +30,7 @@ struct StockView: View {
             ItemListView(items: viewModel.items, onItemStockChangedHandler: viewModel.onItemStockChangedHandler, onRefresh: {
                 await viewModel.fetchItems()
             }, onPaging: {
-                Task {
-                    await viewModel.fetchMoreItems()
-                }
+                await viewModel.fetchMoreItems()
             }).navigationBarTitle("Stock", displayMode: .inline)
         }.onAppear {
             if isInitialOnAppear {


### PR DESCRIPTION
## 概要
- FooterLoadingのインターフェースをrefreshableを参考に変える

## 実装
- asyncを利用してLoadingをBindしなくてよくした
- 1s sleepすることでチカチカする問題を防止
```swift
Task(priority: .userInitiated) {
    indicatorView.startAnimating()
    await action()
    await Task.sleep(1_000_000_000)
    indicatorView.stopAnimating()
}
```
- これによって`onPaging`が`() async -> Void`となり、`Task { }`使わなくなって良くなった