### PR TITLE
データが存在しないことを示すViewを追加する

### DIFF
--- a/Qiita_SwiftUI/Package/Sources/Presentation/Common/EmptyContentView.swift
+++ b/Qiita_SwiftUI/Package/Sources/Presentation/Common/EmptyContentView.swift
@@ -1,0 +1,24 @@
+//
+//  EmptyContentView.swift
+//  
+//
+//  Created by kntk on 2021/11/05.
+//
+
+import SwiftUI
+
+public struct EmptyContentView: View {
+
+    // MARK: - Property
+
+    var title: String
+
+    // MARK: - Public
+
+    public var body: some View {
+        HStack {
+            Text(title)
+                .font(.system(size: 18, weight: .medium))
+        }
+    }
+}

--- a/Qiita_SwiftUI/Package/Sources/Presentation/Screen/Home/HomeView.swift
+++ b/Qiita_SwiftUI/Package/Sources/Presentation/Screen/Home/HomeView.swift
@@ -15,9 +15,6 @@ public struct HomeView: View {
 
     @StateObject private var viewModel: HomeViewModel
 
-    @State private var isInitialOnAppear = true
-
-
     // MARK: - Initializer
 
     init(viewModel: HomeViewModel) {
@@ -28,18 +25,13 @@ public struct HomeView: View {
 
     public var body: some View {
         NavigationView {
-            ItemListView(items: viewModel.items, onItemStock: nil, onRefresh: {
+            ItemListView(items: viewModel.items, onItemStock: nil, onInit: {
+                await viewModel.fetchItems()
+            }, onRefresh: {
                 await viewModel.fetchItems()
             }, onPaging: {
                 await  viewModel.fetchMoreItems()
             }).navigationBarTitle("Home", displayMode: .inline)
-        }.onAppear {
-            if isInitialOnAppear {
-                Task {
-                    await viewModel.fetchItems()
-                }
-                isInitialOnAppear = false
-            }
         }
     }
 }

--- a/Qiita_SwiftUI/Package/Sources/Presentation/Screen/Home/HomeView.swift
+++ b/Qiita_SwiftUI/Package/Sources/Presentation/Screen/Home/HomeView.swift
@@ -28,7 +28,7 @@ public struct HomeView: View {
 
     public var body: some View {
         NavigationView {
-            ItemListView(items: viewModel.items, onItemStockChangedHandler: nil, onRefresh: {
+            ItemListView(items: viewModel.items, onItemStock: nil, onRefresh: {
                 await viewModel.fetchItems()
             }, onPaging: {
                 await  viewModel.fetchMoreItems()

--- a/Qiita_SwiftUI/Package/Sources/Presentation/Screen/Home/HomeView.swift
+++ b/Qiita_SwiftUI/Package/Sources/Presentation/Screen/Home/HomeView.swift
@@ -25,7 +25,7 @@ public struct HomeView: View {
 
     public var body: some View {
         NavigationView {
-            ItemListView(items: viewModel.items, onItemStock: nil, onInit: {
+            ItemListView(items: viewModel.items, emptyTitle: "記事がありません", onItemStock: nil, onInit: {
                 await viewModel.fetchItems()
             }, onRefresh: {
                 await viewModel.fetchItems()

--- a/Qiita_SwiftUI/Package/Sources/Presentation/Screen/ItemList/ItemListItemViewModel.swift
+++ b/Qiita_SwiftUI/Package/Sources/Presentation/Screen/ItemList/ItemListItemViewModel.swift
@@ -20,16 +20,16 @@ public final class ItemListItemViewModel: ObservableObject, Identifiable {
 
     @Published var isStocked: Bool = false
 
-    let onItemStockChangedHandler: ((Item, Bool) -> Void)?
+    let onItemStock: ((_ item: Item, _ status: Bool) -> Void)?
 
     private let stockRepository: StockRepository
     private let likeRepository: LikeRepository
 
     // MARK: - Initializer
 
-    init(item: Item, onItemStockChangedHandler: ((Item, Bool) -> Void)? = nil, stockRepository: StockRepository, likeRepository: LikeRepository) {
+    init(item: Item, onItemStock: ((_ item: Item, _ status: Bool) -> Void)? = nil, stockRepository: StockRepository, likeRepository: LikeRepository) {
         self.item = item
-        self.onItemStockChangedHandler = onItemStockChangedHandler
+        self.onItemStock = onItemStock
         self.stockRepository = stockRepository
         self.likeRepository = likeRepository
     }
@@ -38,7 +38,7 @@ public final class ItemListItemViewModel: ObservableObject, Identifiable {
 
     func stock() async {
         isStocked = true
-        onItemStockChangedHandler?(item, true)
+        onItemStock?(item, true)
         do {
             _ = try await stockRepository.stock(id: item.id)
         } catch {
@@ -49,7 +49,7 @@ public final class ItemListItemViewModel: ObservableObject, Identifiable {
 
     func unStock() async {
         isStocked = false
-        onItemStockChangedHandler?(item, false)
+        onItemStock?(item, false)
         do {
             _ = try await stockRepository.unstock(id: item.id)
         } catch {

--- a/Qiita_SwiftUI/Package/Sources/Presentation/Screen/ItemList/ItemListView.swift
+++ b/Qiita_SwiftUI/Package/Sources/Presentation/Screen/ItemList/ItemListView.swift
@@ -15,7 +15,7 @@ public struct ItemListView<HeaderView: View>: View {
     @EnvironmentObject var repositoryContainer: RepositoryContainer
 
     @State private var isInitialOnAppear = true
-    @State private var isInitialLoading = false
+    @State private var isInitialLoading = true
 
     private let items: [Item]
 

--- a/Qiita_SwiftUI/Package/Sources/Presentation/Screen/ItemList/ItemListView.swift
+++ b/Qiita_SwiftUI/Package/Sources/Presentation/Screen/ItemList/ItemListView.swift
@@ -16,7 +16,7 @@ public struct ItemListView<HeaderView: View>: View {
 
     private let items: [Item]
 
-    private let onItemStockChangedHandler: ((Item, Bool) -> Void)?
+    private let onItemStock: ((_ item: Item, _ status: Bool) -> Void)?
 
     private let onRefresh: () async -> Void
     private let onPaging: () async -> Void
@@ -25,18 +25,18 @@ public struct ItemListView<HeaderView: View>: View {
 
     // MARK: - Initializer
 
-    init(items: [Item], onItemStockChangedHandler: ((Item, Bool) -> Void)? = nil, onRefresh: @escaping () async -> Void, onPaging: @escaping () async -> Void, @ViewBuilder header: () -> HeaderView) {
+    init(items: [Item], onItemStock: ((_ item: Item, _ status: Bool) -> Void)? = nil, onRefresh: @escaping () async -> Void, onPaging: @escaping () async -> Void, @ViewBuilder header: () -> HeaderView) {
         self.items = items
-        self.onItemStockChangedHandler = onItemStockChangedHandler
+        self.onItemStock = onItemStock
         self.onRefresh = onRefresh
         self.onPaging = onPaging
         self.headerView = header()
     }
 
     // headerを使わない場合
-    init(items: [Item], onItemStockChangedHandler: ((Item, Bool) -> Void)? = nil, onRefresh: @escaping () async -> Void, onPaging: @escaping () async -> Void) where HeaderView == EmptyView {
+    init(items: [Item], onItemStock: ((_ item: Item, _ status: Bool) -> Void)? = nil, onRefresh: @escaping () async -> Void, onPaging: @escaping () async -> Void) where HeaderView == EmptyView {
         self.items = items
-        self.onItemStockChangedHandler = onItemStockChangedHandler
+        self.onItemStock = onItemStock
         self.onRefresh = onRefresh
         self.onPaging = onPaging
         self.headerView = EmptyView()
@@ -53,7 +53,7 @@ public struct ItemListView<HeaderView: View>: View {
             headerView
 
             ForEach(items) { item in
-                ItemListItem(viewModel: ItemListItemViewModel(item: item, onItemStockChangedHandler: onItemStockChangedHandler, stockRepository: repositoryContainer.stockRepository, likeRepository: repositoryContainer.likeRepository))
+                ItemListItem(viewModel: ItemListItemViewModel(item: item, onItemStock: onItemStock, stockRepository: repositoryContainer.stockRepository, likeRepository: repositoryContainer.likeRepository))
             }
         }
         .listStyle(PlainListStyle())

--- a/Qiita_SwiftUI/Package/Sources/Presentation/Screen/ItemList/ItemListView.swift
+++ b/Qiita_SwiftUI/Package/Sources/Presentation/Screen/ItemList/ItemListView.swift
@@ -25,12 +25,14 @@ public struct ItemListView<HeaderView: View>: View {
     private let onRefresh: () async -> Void
     private let onPaging: () async -> Void
 
+    private let emptyTitle: String
     private var headerView: HeaderView
 
     // MARK: - Initializer
 
-    init(items: [Item], onItemStock: ((_ item: Item, _ status: Bool) -> Void)? = nil, onInit: @escaping () async -> Void, onRefresh: @escaping () async -> Void, onPaging: @escaping () async -> Void, @ViewBuilder header: () -> HeaderView) {
+    init(items: [Item], emptyTitle: String, onItemStock: ((_ item: Item, _ status: Bool) -> Void)? = nil, onInit: @escaping () async -> Void, onRefresh: @escaping () async -> Void, onPaging: @escaping () async -> Void, @ViewBuilder header: () -> HeaderView) {
         self.items = items
+        self.emptyTitle = emptyTitle
         self.onItemStock = onItemStock
         self.onInit = onInit
         self.onRefresh = onRefresh
@@ -39,8 +41,9 @@ public struct ItemListView<HeaderView: View>: View {
     }
 
     // headerを使わない場合
-    init(items: [Item], onItemStock: ((_ item: Item, _ status: Bool) -> Void)? = nil, onInit: @escaping () async -> Void, onRefresh: @escaping () async -> Void, onPaging: @escaping () async -> Void) where HeaderView == EmptyView {
+    init(items: [Item], emptyTitle: String, onItemStock: ((_ item: Item, _ status: Bool) -> Void)? = nil, onInit: @escaping () async -> Void, onRefresh: @escaping () async -> Void, onPaging: @escaping () async -> Void) where HeaderView == EmptyView {
         self.items = items
+        self.emptyTitle = emptyTitle
         self.onItemStock = onItemStock
         self.onInit = onInit
         self.onRefresh = onRefresh
@@ -60,6 +63,10 @@ public struct ItemListView<HeaderView: View>: View {
                     ProgressView()
                         .scaleEffect(x: 2, y: 2, anchor: .center)
                         .progressViewStyle(CircularProgressViewStyle())
+                        .frame(maxWidth: .infinity)
+                        .frame(height: reader.size.height)
+                } else if items.isEmpty {
+                    EmptyContentView(title: emptyTitle)
                         .frame(maxWidth: .infinity)
                         .frame(height: reader.size.height)
                 } else {

--- a/Qiita_SwiftUI/Package/Sources/Presentation/Screen/Profile/ProfileView.swift
+++ b/Qiita_SwiftUI/Package/Sources/Presentation/Screen/Profile/ProfileView.swift
@@ -29,27 +29,25 @@ public struct ProfileView: View {
     public var body: some View {
         NavigationView {
             Group {
-                if let user = viewModel.user {
-                    VStack(spacing: 0) {
+                VStack(spacing: 0) {
+                    if let user = viewModel.user {
                         UserInformationView(user: user)
-
-                        GeometryReader { reader in
-                            ItemListView(items: viewModel.items, onItemStock: nil, onInit: {
-                                await viewModel.fetchItems()
-                            }, onRefresh: {
-                                await viewModel.fetchItems()
-                            }, onPaging: {
-                                await viewModel.fetchMoreItems()
-                            }, header: {
-                                if !viewModel.isItemLoading && viewModel.items.isEmpty {
-                                    EmptyContentView(title: "投稿記事がありません")
-                                        .frame(width: reader.size.width - 32, height: reader.size.height)
-                                }
-                            })
-                        }
                     }
-                } else {
-                    ProgressView()
+
+                    GeometryReader { reader in
+                        ItemListView(items: viewModel.items, onItemStock: nil, onInit: {
+                            await viewModel.fetchItems()
+                        }, onRefresh: {
+                            await viewModel.fetchItems()
+                        }, onPaging: {
+                            await viewModel.fetchMoreItems()
+                        }, header: {
+                            if let items = viewModel.items, items.isEmpty {
+                                EmptyContentView(title: "投稿記事がありません")
+                                    .frame(height: reader.size.height)
+                            }
+                        })
+                    }
                 }
             }
             .navigationBarTitle("Profile", displayMode: .inline)

--- a/Qiita_SwiftUI/Package/Sources/Presentation/Screen/Profile/ProfileView.swift
+++ b/Qiita_SwiftUI/Package/Sources/Presentation/Screen/Profile/ProfileView.swift
@@ -34,7 +34,7 @@ public struct ProfileView: View {
                         UserInformationView(user: user)
 
                         GeometryReader { reader in
-                            ItemListView(items: viewModel.items, onItemStockChangedHandler: nil, onRefresh: {
+                            ItemListView(items: viewModel.items, onItemStock: nil, onRefresh: {
                                 await viewModel.fetchItems()
                             }, onPaging: {
                                 await viewModel.fetchMoreItems()

--- a/Qiita_SwiftUI/Package/Sources/Presentation/Screen/Profile/ProfileView.swift
+++ b/Qiita_SwiftUI/Package/Sources/Presentation/Screen/Profile/ProfileView.swift
@@ -34,7 +34,9 @@ public struct ProfileView: View {
                         UserInformationView(user: user)
 
                         GeometryReader { reader in
-                            ItemListView(items: viewModel.items, onItemStock: nil, onRefresh: {
+                            ItemListView(items: viewModel.items, onItemStock: nil, onInit: {
+                                await viewModel.fetchItems()
+                            }, onRefresh: {
                                 await viewModel.fetchItems()
                             }, onPaging: {
                                 await viewModel.fetchMoreItems()
@@ -59,7 +61,7 @@ public struct ProfileView: View {
         }.onAppear {
             if isInitialOnAppear {
                 Task {
-                    await (viewModel.fetchUser(), viewModel.fetchItems())
+                    await viewModel.fetchUser()
                 }
 
                 isInitialOnAppear = false

--- a/Qiita_SwiftUI/Package/Sources/Presentation/Screen/Profile/ProfileView.swift
+++ b/Qiita_SwiftUI/Package/Sources/Presentation/Screen/Profile/ProfileView.swift
@@ -35,17 +35,12 @@ public struct ProfileView: View {
                     }
 
                     GeometryReader { reader in
-                        ItemListView(items: viewModel.items, onItemStock: nil, onInit: {
+                        ItemListView(items: viewModel.items, emptyTitle: "投稿記事がありません", onItemStock: nil, onInit: {
                             await viewModel.fetchItems()
                         }, onRefresh: {
                             await viewModel.fetchItems()
                         }, onPaging: {
                             await viewModel.fetchMoreItems()
-                        }, header: {
-                            if let items = viewModel.items, items.isEmpty {
-                                EmptyContentView(title: "投稿記事がありません")
-                                    .frame(height: reader.size.height)
-                            }
                         })
                     }
                 }

--- a/Qiita_SwiftUI/Package/Sources/Presentation/Screen/Profile/ProfileView.swift
+++ b/Qiita_SwiftUI/Package/Sources/Presentation/Screen/Profile/ProfileView.swift
@@ -33,11 +33,18 @@ public struct ProfileView: View {
                     VStack(spacing: 0) {
                         UserInformationView(user: user)
 
-                        ItemListView(items: viewModel.items, onItemStockChangedHandler: nil, onRefresh: {
-                            await viewModel.fetchItems()
-                        }, onPaging: {
-                            await viewModel.fetchMoreItems()
-                        })
+                        GeometryReader { reader in
+                            ItemListView(items: viewModel.items, onItemStockChangedHandler: nil, onRefresh: {
+                                await viewModel.fetchItems()
+                            }, onPaging: {
+                                await viewModel.fetchMoreItems()
+                            }, header: {
+                                if !viewModel.isItemLoading && viewModel.items.isEmpty {
+                                    EmptyContentView(title: "投稿記事がありません")
+                                        .frame(width: reader.size.width - 32, height: reader.size.height)
+                                }
+                            })
+                        }
                     }
                 } else {
                     ProgressView()

--- a/Qiita_SwiftUI/Package/Sources/Presentation/Screen/Profile/ProfileView.swift
+++ b/Qiita_SwiftUI/Package/Sources/Presentation/Screen/Profile/ProfileView.swift
@@ -34,15 +34,13 @@ public struct ProfileView: View {
                         UserInformationView(user: user)
                     }
 
-                    GeometryReader { reader in
-                        ItemListView(items: viewModel.items, emptyTitle: "投稿記事がありません", onItemStock: nil, onInit: {
-                            await viewModel.fetchItems()
-                        }, onRefresh: {
-                            await viewModel.fetchItems()
-                        }, onPaging: {
-                            await viewModel.fetchMoreItems()
-                        })
-                    }
+                    ItemListView(items: viewModel.items, emptyTitle: "投稿記事がありません", onItemStock: nil, onInit: {
+                        await viewModel.fetchItems()
+                    }, onRefresh: {
+                        await viewModel.fetchItems()
+                    }, onPaging: {
+                        await viewModel.fetchMoreItems()
+                    })
                 }
             }
             .navigationBarTitle("Profile", displayMode: .inline)

--- a/Qiita_SwiftUI/Package/Sources/Presentation/Screen/Profile/ProfileViewModel.swift
+++ b/Qiita_SwiftUI/Package/Sources/Presentation/Screen/Profile/ProfileViewModel.swift
@@ -17,7 +17,6 @@ public final class ProfileViewModel: ObservableObject {
 
     @Published var user: User?
     @Published var items: [Item] = []
-    @Published var isItemLoading: Bool = false
 
     private var page = 1
     private var isPageLoading = false
@@ -43,14 +42,12 @@ public final class ProfileViewModel: ObservableObject {
     }
 
     func fetchItems() async {
-        isItemLoading = true
         do {
             items = try await itemRepository.getAuthenticatedUserItems(page: 1, perPage: 20)
             page = 1
         } catch {
             Logger.error(error)
         }
-        isItemLoading = false
     }
 
     func fetchMoreItems() async {

--- a/Qiita_SwiftUI/Package/Sources/Presentation/Screen/Profile/ProfileViewModel.swift
+++ b/Qiita_SwiftUI/Package/Sources/Presentation/Screen/Profile/ProfileViewModel.swift
@@ -17,6 +17,7 @@ public final class ProfileViewModel: ObservableObject {
 
     @Published var user: User?
     @Published var items: [Item] = []
+    @Published var isItemLoading: Bool = false
 
     private var page = 1
     private var isPageLoading = false
@@ -42,12 +43,14 @@ public final class ProfileViewModel: ObservableObject {
     }
 
     func fetchItems() async {
+        isItemLoading = true
         do {
             items = try await itemRepository.getAuthenticatedUserItems(page: 1, perPage: 20)
             page = 1
         } catch {
             Logger.error(error)
         }
+        isItemLoading = false
     }
 
     func fetchMoreItems() async {

--- a/Qiita_SwiftUI/Package/Sources/Presentation/Screen/SearchResult/SearchResultView.swift
+++ b/Qiita_SwiftUI/Package/Sources/Presentation/Screen/SearchResult/SearchResultView.swift
@@ -16,8 +16,6 @@ public struct SearchResultView: View {
 
     @StateObject private var viewModel: SearchResultViewModel
 
-    @State private var isInitialOnAppear = true
-
     // MARK: - Initializer
 
     init(viewModel: SearchResultViewModel) {
@@ -30,7 +28,9 @@ public struct SearchResultView: View {
         /// FIXME: ItemListViewのHeaderが左寄せになっている問題
         /// 現在はSearchResultの方で幅を指定して対応
         GeometryReader { reader in
-            ItemListView(items: viewModel.items, onItemStock: nil, onRefresh: {
+            ItemListView(items: viewModel.items, onItemStock: nil, onInit: {
+                await viewModel.fetchItems()
+            }, onRefresh: {
                 await viewModel.fetchItems()
             }, onPaging: {
                 await viewModel.fetchMoreItems()
@@ -46,14 +46,6 @@ public struct SearchResultView: View {
                 }
             })
             .navigationTitle(navigationTitle)
-            .onAppear {
-                if isInitialOnAppear {
-                    Task {
-                        await viewModel.fetchItems()
-                    }
-                    isInitialOnAppear = false
-                }
-            }
         }
     }
 

--- a/Qiita_SwiftUI/Package/Sources/Presentation/Screen/SearchResult/SearchResultView.swift
+++ b/Qiita_SwiftUI/Package/Sources/Presentation/Screen/SearchResult/SearchResultView.swift
@@ -30,7 +30,7 @@ public struct SearchResultView: View {
         /// FIXME: ItemListViewのHeaderが左寄せになっている問題
         /// 現在はSearchResultの方で幅を指定して対応
         GeometryReader { reader in
-            ItemListView(items: viewModel.items, onItemStockChangedHandler: nil, onRefresh: {
+            ItemListView(items: viewModel.items, onItemStock: nil, onRefresh: {
                 await viewModel.fetchItems()
             }, onPaging: {
                 await viewModel.fetchMoreItems()

--- a/Qiita_SwiftUI/Package/Sources/Presentation/Screen/SearchResult/SearchResultView.swift
+++ b/Qiita_SwiftUI/Package/Sources/Presentation/Screen/SearchResult/SearchResultView.swift
@@ -26,7 +26,7 @@ public struct SearchResultView: View {
 
     public var body: some View {
         GeometryReader { reader in
-            ItemListView(items: viewModel.items, onItemStock: nil, onInit: {
+            ItemListView(items: viewModel.items, emptyTitle: "記事がありません", onItemStock: nil, onInit: {
                 await viewModel.fetchItems()
             }, onRefresh: {
                 await viewModel.fetchItems()
@@ -36,10 +36,6 @@ public struct SearchResultView: View {
                 if case .tag(let tag) = viewModel.searchType {
                     // タグ検索の場合、結果が空にならないという想定
                     TagInformationView(viewModel: TagInformationViewModel(tag: tag, tagRepository: repositoryContainer.tagRepository))
-                } else if let items = viewModel.items, items.isEmpty {
-                    // タグ検索以外 かつ 結果が読み込まれた かつ 結果が空
-                    EmptyContentView(title: "記事がありません")
-                        .frame(height: reader.size.height)
                 }
             })
             .navigationTitle(navigationTitle)

--- a/Qiita_SwiftUI/Package/Sources/Presentation/Screen/SearchResult/SearchResultView.swift
+++ b/Qiita_SwiftUI/Package/Sources/Presentation/Screen/SearchResult/SearchResultView.swift
@@ -33,13 +33,16 @@ public struct SearchResultView: View {
             ItemListView(items: viewModel.items, onItemStockChangedHandler: nil, onRefresh: {
                 await viewModel.fetchItems()
             }, onPaging: {
-                Task {
-                    await viewModel.fetchMoreItems()
-                }
+                await viewModel.fetchMoreItems()
             }, header: {
-                if case .tag(let tag) = viewModel.searchType {
-                    TagInformationView(viewModel: TagInformationViewModel(tag: tag, tagRepository: repositoryContainer.tagRepository))
-                        .frame(width: reader.size.width - 32)
+                if !viewModel.isLoading && viewModel.items.isEmpty {
+                    EmptyContentView(title: "記事がありません")
+                        .frame(width: reader.size.width - 32, height: reader.size.height)
+                } else {
+                    if case .tag(let tag) = viewModel.searchType {
+                        TagInformationView(viewModel: TagInformationViewModel(tag: tag, tagRepository: repositoryContainer.tagRepository))
+                            .frame(width: reader.size.width - 32)
+                    }
                 }
             })
             .navigationTitle(navigationTitle)

--- a/Qiita_SwiftUI/Package/Sources/Presentation/Screen/SearchResult/SearchResultView.swift
+++ b/Qiita_SwiftUI/Package/Sources/Presentation/Screen/SearchResult/SearchResultView.swift
@@ -25,8 +25,6 @@ public struct SearchResultView: View {
     // MARK: - Body
 
     public var body: some View {
-        /// FIXME: ItemListViewのHeaderが左寄せになっている問題
-        /// 現在はSearchResultの方で幅を指定して対応
         GeometryReader { reader in
             ItemListView(items: viewModel.items, onItemStock: nil, onInit: {
                 await viewModel.fetchItems()
@@ -35,14 +33,13 @@ public struct SearchResultView: View {
             }, onPaging: {
                 await viewModel.fetchMoreItems()
             }, header: {
-                if !viewModel.isLoading && viewModel.items.isEmpty {
+                if case .tag(let tag) = viewModel.searchType {
+                    // タグ検索の場合、結果が空にならないという想定
+                    TagInformationView(viewModel: TagInformationViewModel(tag: tag, tagRepository: repositoryContainer.tagRepository))
+                } else if let items = viewModel.items, items.isEmpty {
+                    // タグ検索以外 かつ 結果が読み込まれた かつ 結果が空
                     EmptyContentView(title: "記事がありません")
-                        .frame(width: reader.size.width - 32, height: reader.size.height)
-                } else {
-                    if case .tag(let tag) = viewModel.searchType {
-                        TagInformationView(viewModel: TagInformationViewModel(tag: tag, tagRepository: repositoryContainer.tagRepository))
-                            .frame(width: reader.size.width - 32)
-                    }
+                        .frame(height: reader.size.height)
                 }
             })
             .navigationTitle(navigationTitle)

--- a/Qiita_SwiftUI/Package/Sources/Presentation/Screen/SearchResult/SearchResultViewModel.swift
+++ b/Qiita_SwiftUI/Package/Sources/Presentation/Screen/SearchResult/SearchResultViewModel.swift
@@ -16,6 +16,8 @@ public final class SearchResultViewModel: ObservableObject {
     // MARK: - Property
 
     @Published var items: [Item] = []
+    @Published var isLoading: Bool = false
+
     let searchType: SearchType
 
     private var page = 1
@@ -33,19 +35,21 @@ public final class SearchResultViewModel: ObservableObject {
     // MARK: - Public
 
     func fetchItems() async {
+        isLoading = true
         do {
             items = try await itemRepository.getItems(with: searchType, page: 1)
             page = 1
         } catch {
             Logger.error(error)
         }
+        isLoading = false
     }
 
     func fetchMoreItems() async {
         if isPageLoading { return }
         isPageLoading = true
         do {
-            items += try await itemRepository.getItems(page: page + 1)
+            items += try await itemRepository.getItems(with: searchType, page: page + 1)
             page += 1
         } catch {
             Logger.error(error)

--- a/Qiita_SwiftUI/Package/Sources/Presentation/Screen/Stock/StockView.swift
+++ b/Qiita_SwiftUI/Package/Sources/Presentation/Screen/Stock/StockView.swift
@@ -28,7 +28,7 @@ public struct StockView: View {
     public var body: some View {
         NavigationView {
             GeometryReader { reader in
-                ItemListView(items: viewModel.items, onItemStockChangedHandler: viewModel.onItemStockChangedHandler, onRefresh: {
+                ItemListView(items: viewModel.items, onItemStock: viewModel.onItemStock, onRefresh: {
                     await viewModel.fetchItems()
                 }, onPaging: {
                     await viewModel.fetchMoreItems()

--- a/Qiita_SwiftUI/Package/Sources/Presentation/Screen/Stock/StockView.swift
+++ b/Qiita_SwiftUI/Package/Sources/Presentation/Screen/Stock/StockView.swift
@@ -33,9 +33,9 @@ public struct StockView: View {
                 }, onPaging: {
                     await viewModel.fetchMoreItems()
                 }, header: {
-                    if !viewModel.isLoading && viewModel.items.isEmpty {
+                    if viewModel.items.isEmpty {
                         EmptyContentView(title: "ストックされた記事がありません")
-                            .frame(width: reader.size.width - 32, height: reader.size.height)
+                            .frame(height: reader.size.height)
                     }
                 })
             }.navigationBarTitle("Stock", displayMode: .inline)

--- a/Qiita_SwiftUI/Package/Sources/Presentation/Screen/Stock/StockView.swift
+++ b/Qiita_SwiftUI/Package/Sources/Presentation/Screen/Stock/StockView.swift
@@ -27,11 +27,18 @@ public struct StockView: View {
 
     public var body: some View {
         NavigationView {
-            ItemListView(items: viewModel.items, onItemStockChangedHandler: viewModel.onItemStockChangedHandler, onRefresh: {
-                await viewModel.fetchItems()
-            }, onPaging: {
-                await viewModel.fetchMoreItems()
-            }).navigationBarTitle("Stock", displayMode: .inline)
+            GeometryReader { reader in
+                ItemListView(items: viewModel.items, onItemStockChangedHandler: viewModel.onItemStockChangedHandler, onRefresh: {
+                    await viewModel.fetchItems()
+                }, onPaging: {
+                    await viewModel.fetchMoreItems()
+                }, header: {
+                    if !viewModel.isLoading && viewModel.items.isEmpty {
+                        EmptyContentView(title: "ストックされた記事がありません")
+                            .frame(width: reader.size.width - 32, height: reader.size.height)
+                    }
+                })
+            }.navigationBarTitle("Stock", displayMode: .inline)
         }.onAppear {
             if isInitialOnAppear {
                 Task {

--- a/Qiita_SwiftUI/Package/Sources/Presentation/Screen/Stock/StockView.swift
+++ b/Qiita_SwiftUI/Package/Sources/Presentation/Screen/Stock/StockView.swift
@@ -15,8 +15,6 @@ public struct StockView: View {
 
     @StateObject private var viewModel: StockViewModel
 
-    @State private var isInitialOnAppear = true
-
     // MARK: - Initializer
 
     init(viewModel: StockViewModel) {
@@ -28,7 +26,9 @@ public struct StockView: View {
     public var body: some View {
         NavigationView {
             GeometryReader { reader in
-                ItemListView(items: viewModel.items, onItemStock: viewModel.onItemStock, onRefresh: {
+                ItemListView(items: viewModel.items, onItemStock: viewModel.onItemStock, onInit: {
+                    await viewModel.fetchItems()
+                }, onRefresh: {
                     await viewModel.fetchItems()
                 }, onPaging: {
                     await viewModel.fetchMoreItems()
@@ -39,13 +39,6 @@ public struct StockView: View {
                     }
                 })
             }.navigationBarTitle("Stock", displayMode: .inline)
-        }.onAppear {
-            if isInitialOnAppear {
-                Task {
-                    await viewModel.fetchItems()
-                }
-                isInitialOnAppear = false
-            }
         }
     }
 }

--- a/Qiita_SwiftUI/Package/Sources/Presentation/Screen/Stock/StockView.swift
+++ b/Qiita_SwiftUI/Package/Sources/Presentation/Screen/Stock/StockView.swift
@@ -26,17 +26,12 @@ public struct StockView: View {
     public var body: some View {
         NavigationView {
             GeometryReader { reader in
-                ItemListView(items: viewModel.items, onItemStock: viewModel.onItemStock, onInit: {
+                ItemListView(items: viewModel.items, emptyTitle: "ストックした記事はありません", onItemStock: viewModel.onItemStock, onInit: {
                     await viewModel.fetchItems()
                 }, onRefresh: {
                     await viewModel.fetchItems()
                 }, onPaging: {
                     await viewModel.fetchMoreItems()
-                }, header: {
-                    if viewModel.items.isEmpty {
-                        EmptyContentView(title: "ストックされた記事がありません")
-                            .frame(height: reader.size.height)
-                    }
                 })
             }.navigationBarTitle("Stock", displayMode: .inline)
         }

--- a/Qiita_SwiftUI/Package/Sources/Presentation/Screen/Stock/StockViewModel.swift
+++ b/Qiita_SwiftUI/Package/Sources/Presentation/Screen/Stock/StockViewModel.swift
@@ -16,6 +16,7 @@ public final class StockViewModel: ObservableObject {
     // MARK: - Property
 
     @Published var items: [Item] = []
+    @Published var isLoading: Bool = false
 
     private(set) var onItemStockChangedHandler: ((Item, Bool) -> Void)?
 
@@ -38,12 +39,14 @@ public final class StockViewModel: ObservableObject {
     // MARK: - Public
 
     func fetchItems() async {
+        isLoading = true
         do {
             items = try await stockRepository.getStocks(page: 1, perPage: 20)
             page = 1
         } catch {
             Logger.error(error)
         }
+        isLoading = false
     }
 
     func fetchMoreItems() async {

--- a/Qiita_SwiftUI/Package/Sources/Presentation/Screen/Stock/StockViewModel.swift
+++ b/Qiita_SwiftUI/Package/Sources/Presentation/Screen/Stock/StockViewModel.swift
@@ -18,7 +18,7 @@ public final class StockViewModel: ObservableObject {
     @Published var items: [Item] = []
     @Published var isLoading: Bool = false
 
-    private(set) var onItemStockChangedHandler: ((Item, Bool) -> Void)?
+    private(set) var onItemStock: ((_ item: Item, _ status: Bool) -> Void)?
 
     private var page = 1
     private var isPageLoading = false
@@ -30,7 +30,7 @@ public final class StockViewModel: ObservableObject {
     init(stockRepository: StockRepository) {
         self.stockRepository = stockRepository
 
-        self.onItemStockChangedHandler = { [weak self] (item, status) in
+        self.onItemStock = { [weak self] (item, status) in
             guard let self = self, let targetIndex = self.items.firstIndex(where: { $0.id == item.id }) else { return }
             self.items.remove(at: targetIndex)
         }


### PR DESCRIPTION
## 概要
- List等で表示するデータがなかった場合にデータがないことを示すためのViewを追加する

## 実装
- `EmptyContentView`を追加
    - `EmptyView`が良かったが、SwiftUIの空Viewと名前被りしたため
- `ItemListView`内で`EmptyContentView`を利用する
    - `item.isEmpty`だけでは、未初期化状態なのか結果が空なのかわからないため
    初期データ取得のための関数`onInit`を受け取り、`onInit`が終了したフラグ`isInitialLoading`を併用することで適切に表示する
    - ついでにLoadingのクルクルも実装
```swift
if isInitialLoading {
    // ローディングのクルクル
} else if item.isEmpty {
    // EmptyView
} else {
    // 普通のデータ表示
}
```
- ヘッダーがセンター表示できない問題は`.frame(maxWidth: .infinity)`で解決

| EmptyContentView | クルクル |
| ------ | ------ |
| ![Simulator Screen Shot - iPhone 13 - 2021-11-06 at 01 31 41](https://user-images.githubusercontent.com/44288050/140546151-fe0224db-81b8-4888-82bb-7f7838231458.png) | ![Simulator Screen Shot - iPhone 13 - 2021-11-06 at 01 21 39](https://user-images.githubusercontent.com/44288050/140546219-ac482ca1-df97-4ef0-8204-c57a5dc2a9ec.png)|